### PR TITLE
Create JWT + Validate JWT Functionality

### DIFF
--- a/packages/api-gateway/src/auth-service/gen/api_key.ts
+++ b/packages/api-gateway/src/auth-service/gen/api_key.ts
@@ -1,20 +1,16 @@
 /* eslint-disable */
-import { GrpcMethod, GrpcStreamMethod } from "@nestjs/microservices";
-import { Observable } from "rxjs";
+import { GrpcMethod, GrpcStreamMethod } from '@nestjs/microservices';
+import { Observable } from 'rxjs';
 
-export const protobufPackage = "authservice.api_key";
+export const protobufPackage = 'authservice.api_key';
 
-export interface IssueApiKeyRequest {
-}
+export interface IssueApiKeyRequest {}
 
-export interface IssueApiKeyResponse {
-}
+export interface IssueApiKeyResponse {}
 
-export interface RevokeApiKeyRequest {
-}
+export interface RevokeApiKeyRequest {}
 
-export interface RevokeApiKeyResponse {
-}
+export interface RevokeApiKeyResponse {}
 
 export interface GetProjectByApiKeyRequest {
   apiKey: string;
@@ -37,49 +33,84 @@ export interface GetHashedApiKeyResponse {
   error?: string | undefined;
 }
 
-export const AUTHSERVICE_API_KEY_PACKAGE_NAME = "authservice.api_key";
+export const AUTHSERVICE_API_KEY_PACKAGE_NAME = 'authservice.api_key';
 
 export interface ApiKeyServiceClient {
   issueApiKey(request: IssueApiKeyRequest): Observable<IssueApiKeyResponse>;
 
   revokeApiKey(request: RevokeApiKeyRequest): Observable<RevokeApiKeyResponse>;
 
-  getProjectByApiKey(request: GetProjectByApiKeyRequest): Observable<GetProjectByApiKeyResponse>;
+  getProjectByApiKey(
+    request: GetProjectByApiKeyRequest,
+  ): Observable<GetProjectByApiKeyResponse>;
 
-  getHashedApiKey(request: GetHashedApiKeyRequest): Observable<GetHashedApiKeyResponse>;
+  getHashedApiKey(
+    request: GetHashedApiKeyRequest,
+  ): Observable<GetHashedApiKeyResponse>;
 }
 
 export interface ApiKeyServiceController {
   issueApiKey(
     request: IssueApiKeyRequest,
-  ): Promise<IssueApiKeyResponse> | Observable<IssueApiKeyResponse> | IssueApiKeyResponse;
+  ):
+    | Promise<IssueApiKeyResponse>
+    | Observable<IssueApiKeyResponse>
+    | IssueApiKeyResponse;
 
   revokeApiKey(
     request: RevokeApiKeyRequest,
-  ): Promise<RevokeApiKeyResponse> | Observable<RevokeApiKeyResponse> | RevokeApiKeyResponse;
+  ):
+    | Promise<RevokeApiKeyResponse>
+    | Observable<RevokeApiKeyResponse>
+    | RevokeApiKeyResponse;
 
   getProjectByApiKey(
     request: GetProjectByApiKeyRequest,
-  ): Promise<GetProjectByApiKeyResponse> | Observable<GetProjectByApiKeyResponse> | GetProjectByApiKeyResponse;
+  ):
+    | Promise<GetProjectByApiKeyResponse>
+    | Observable<GetProjectByApiKeyResponse>
+    | GetProjectByApiKeyResponse;
 
   getHashedApiKey(
     request: GetHashedApiKeyRequest,
-  ): Promise<GetHashedApiKeyResponse> | Observable<GetHashedApiKeyResponse> | GetHashedApiKeyResponse;
+  ):
+    | Promise<GetHashedApiKeyResponse>
+    | Observable<GetHashedApiKeyResponse>
+    | GetHashedApiKeyResponse;
 }
 
 export function ApiKeyServiceControllerMethods() {
   return function (constructor: Function) {
-    const grpcMethods: string[] = ["issueApiKey", "revokeApiKey", "getProjectByApiKey", "getHashedApiKey"];
+    const grpcMethods: string[] = [
+      'issueApiKey',
+      'revokeApiKey',
+      'getProjectByApiKey',
+      'getHashedApiKey',
+    ];
     for (const method of grpcMethods) {
-      const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
-      GrpcMethod("ApiKeyService", method)(constructor.prototype[method], method, descriptor);
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(
+        constructor.prototype,
+        method,
+      );
+      GrpcMethod('ApiKeyService', method)(
+        constructor.prototype[method],
+        method,
+        descriptor,
+      );
     }
     const grpcStreamMethods: string[] = [];
     for (const method of grpcStreamMethods) {
-      const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
-      GrpcStreamMethod("ApiKeyService", method)(constructor.prototype[method], method, descriptor);
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(
+        constructor.prototype,
+        method,
+      );
+      GrpcStreamMethod('ApiKeyService', method)(
+        constructor.prototype[method],
+        method,
+        descriptor,
+      );
     }
   };
 }
 
-export const API_KEY_SERVICE_NAME = "ApiKeyService";
+export const API_KEY_SERVICE_NAME = 'ApiKeyService';

--- a/packages/api-gateway/src/auth-service/gen/api_key.ts
+++ b/packages/api-gateway/src/auth-service/gen/api_key.ts
@@ -1,68 +1,64 @@
 /* eslint-disable */
-import { GrpcMethod, GrpcStreamMethod } from '@nestjs/microservices';
-import { Observable } from 'rxjs';
+import { GrpcMethod, GrpcStreamMethod } from "@nestjs/microservices";
+import { Observable } from "rxjs";
 
-export const protobufPackage = 'authservice.api_key';
+export const protobufPackage = "authservice.api_key";
 
-export interface IssueApiKeyRequest {}
+export interface IssueApiKeyRequest {
+}
 
-export interface IssueApiKeyResponse {}
+export interface IssueApiKeyResponse {
+}
 
-export interface RevokeApiKeyRequest {}
+export interface RevokeApiKeyRequest {
+}
 
-export interface RevokeApiKeyResponse {}
+export interface RevokeApiKeyResponse {
+}
 
-export const AUTHSERVICE_API_KEY_PACKAGE_NAME = 'authservice.api_key';
+export interface IsValidApiKeyRequest {
+}
+
+export interface IsValidApiKeyResponse {
+}
+
+export const AUTHSERVICE_API_KEY_PACKAGE_NAME = "authservice.api_key";
 
 export interface ApiKeyServiceClient {
   issueApiKey(request: IssueApiKeyRequest): Observable<IssueApiKeyResponse>;
 
   revokeApiKey(request: RevokeApiKeyRequest): Observable<RevokeApiKeyResponse>;
+
+  isValidApiKey(request: IsValidApiKeyRequest): Observable<IsValidApiKeyResponse>;
 }
 
 export interface ApiKeyServiceController {
   issueApiKey(
     request: IssueApiKeyRequest,
-  ):
-    | Promise<IssueApiKeyResponse>
-    | Observable<IssueApiKeyResponse>
-    | IssueApiKeyResponse;
+  ): Promise<IssueApiKeyResponse> | Observable<IssueApiKeyResponse> | IssueApiKeyResponse;
 
   revokeApiKey(
     request: RevokeApiKeyRequest,
-  ):
-    | Promise<RevokeApiKeyResponse>
-    | Observable<RevokeApiKeyResponse>
-    | RevokeApiKeyResponse;
+  ): Promise<RevokeApiKeyResponse> | Observable<RevokeApiKeyResponse> | RevokeApiKeyResponse;
+
+  isValidApiKey(
+    request: IsValidApiKeyRequest,
+  ): Promise<IsValidApiKeyResponse> | Observable<IsValidApiKeyResponse> | IsValidApiKeyResponse;
 }
 
 export function ApiKeyServiceControllerMethods() {
   return function (constructor: Function) {
-    const grpcMethods: string[] = ['issueApiKey', 'revokeApiKey'];
+    const grpcMethods: string[] = ["issueApiKey", "revokeApiKey", "isValidApiKey"];
     for (const method of grpcMethods) {
-      const descriptor: any = Reflect.getOwnPropertyDescriptor(
-        constructor.prototype,
-        method,
-      );
-      GrpcMethod('ApiKeyService', method)(
-        constructor.prototype[method],
-        method,
-        descriptor,
-      );
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
+      GrpcMethod("ApiKeyService", method)(constructor.prototype[method], method, descriptor);
     }
     const grpcStreamMethods: string[] = [];
     for (const method of grpcStreamMethods) {
-      const descriptor: any = Reflect.getOwnPropertyDescriptor(
-        constructor.prototype,
-        method,
-      );
-      GrpcStreamMethod('ApiKeyService', method)(
-        constructor.prototype[method],
-        method,
-        descriptor,
-      );
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
+      GrpcStreamMethod("ApiKeyService", method)(constructor.prototype[method], method, descriptor);
     }
   };
 }
 
-export const API_KEY_SERVICE_NAME = 'ApiKeyService';
+export const API_KEY_SERVICE_NAME = "ApiKeyService";

--- a/packages/api-gateway/src/auth-service/gen/api_key.ts
+++ b/packages/api-gateway/src/auth-service/gen/api_key.ts
@@ -16,10 +16,25 @@ export interface RevokeApiKeyRequest {
 export interface RevokeApiKeyResponse {
 }
 
-export interface IsValidApiKeyRequest {
+export interface GetProjectByApiKeyRequest {
+  apiKey: string;
 }
 
-export interface IsValidApiKeyResponse {
+export interface GetProjectByApiKeyResponse {
+  success: boolean;
+  projectId?: string | undefined;
+  scopes: string[];
+  error?: string | undefined;
+}
+
+export interface GetHashedApiKeyRequest {
+  apiKey: string;
+}
+
+export interface GetHashedApiKeyResponse {
+  success: boolean;
+  hashedApiKey?: string | undefined;
+  error?: string | undefined;
 }
 
 export const AUTHSERVICE_API_KEY_PACKAGE_NAME = "authservice.api_key";
@@ -29,7 +44,9 @@ export interface ApiKeyServiceClient {
 
   revokeApiKey(request: RevokeApiKeyRequest): Observable<RevokeApiKeyResponse>;
 
-  isValidApiKey(request: IsValidApiKeyRequest): Observable<IsValidApiKeyResponse>;
+  getProjectByApiKey(request: GetProjectByApiKeyRequest): Observable<GetProjectByApiKeyResponse>;
+
+  getHashedApiKey(request: GetHashedApiKeyRequest): Observable<GetHashedApiKeyResponse>;
 }
 
 export interface ApiKeyServiceController {
@@ -41,14 +58,18 @@ export interface ApiKeyServiceController {
     request: RevokeApiKeyRequest,
   ): Promise<RevokeApiKeyResponse> | Observable<RevokeApiKeyResponse> | RevokeApiKeyResponse;
 
-  isValidApiKey(
-    request: IsValidApiKeyRequest,
-  ): Promise<IsValidApiKeyResponse> | Observable<IsValidApiKeyResponse> | IsValidApiKeyResponse;
+  getProjectByApiKey(
+    request: GetProjectByApiKeyRequest,
+  ): Promise<GetProjectByApiKeyResponse> | Observable<GetProjectByApiKeyResponse> | GetProjectByApiKeyResponse;
+
+  getHashedApiKey(
+    request: GetHashedApiKeyRequest,
+  ): Promise<GetHashedApiKeyResponse> | Observable<GetHashedApiKeyResponse> | GetHashedApiKeyResponse;
 }
 
 export function ApiKeyServiceControllerMethods() {
   return function (constructor: Function) {
-    const grpcMethods: string[] = ["issueApiKey", "revokeApiKey", "isValidApiKey"];
+    const grpcMethods: string[] = ["issueApiKey", "revokeApiKey", "getProjectByApiKey", "getHashedApiKey"];
     for (const method of grpcMethods) {
       const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
       GrpcMethod("ApiKeyService", method)(constructor.prototype[method], method, descriptor);

--- a/packages/api-gateway/src/auth-service/gen/api_key.ts
+++ b/packages/api-gateway/src/auth-service/gen/api_key.ts
@@ -33,6 +33,16 @@ export interface GetHashedApiKeyResponse {
   error?: string | undefined;
 }
 
+export interface ValidateHashedApiKeyRequest {
+  hashedApiKey: string;
+}
+
+export interface ValidateHashedApiKeyResponse {
+  success: boolean;
+  validHash: boolean;
+  error?: string | undefined;
+}
+
 export const AUTHSERVICE_API_KEY_PACKAGE_NAME = 'authservice.api_key';
 
 export interface ApiKeyServiceClient {
@@ -47,6 +57,10 @@ export interface ApiKeyServiceClient {
   getHashedApiKey(
     request: GetHashedApiKeyRequest,
   ): Observable<GetHashedApiKeyResponse>;
+
+  validateHashedApiKey(
+    request: ValidateHashedApiKeyRequest,
+  ): Observable<ValidateHashedApiKeyResponse>;
 }
 
 export interface ApiKeyServiceController {
@@ -77,6 +91,13 @@ export interface ApiKeyServiceController {
     | Promise<GetHashedApiKeyResponse>
     | Observable<GetHashedApiKeyResponse>
     | GetHashedApiKeyResponse;
+
+  validateHashedApiKey(
+    request: ValidateHashedApiKeyRequest,
+  ):
+    | Promise<ValidateHashedApiKeyResponse>
+    | Observable<ValidateHashedApiKeyResponse>
+    | ValidateHashedApiKeyResponse;
 }
 
 export function ApiKeyServiceControllerMethods() {
@@ -86,6 +107,7 @@ export function ApiKeyServiceControllerMethods() {
       'revokeApiKey',
       'getProjectByApiKey',
       'getHashedApiKey',
+      'validateHashedApiKey',
     ];
     for (const method of grpcMethods) {
       const descriptor: any = Reflect.getOwnPropertyDescriptor(

--- a/packages/api-gateway/src/auth-service/gen/jwt.ts
+++ b/packages/api-gateway/src/auth-service/gen/jwt.ts
@@ -1,18 +1,30 @@
 /* eslint-disable */
-import { GrpcMethod, GrpcStreamMethod } from '@nestjs/microservices';
-import { Observable } from 'rxjs';
+import { GrpcMethod, GrpcStreamMethod } from "@nestjs/microservices";
+import { Observable } from "rxjs";
 
-export const protobufPackage = 'authservice.jwt';
+export const protobufPackage = "authservice.jwt";
 
-export interface CreateJwtRequest {}
+export interface CreateJwtRequestHeader {
+  XApiKey: string;
+}
 
-export interface CreateJwtResponse {}
+export interface CreateJwtRequest {
+  header: CreateJwtRequestHeader | undefined;
+}
 
-export interface ValidateJwtRequest {}
+export interface CreateJwtResponse {
+  success: boolean;
+  error: string;
+  jwt?: string | undefined;
+}
 
-export interface ValidateJwtResponse {}
+export interface ValidateJwtRequest {
+}
 
-export const AUTHSERVICE_JWT_PACKAGE_NAME = 'authservice.jwt';
+export interface ValidateJwtResponse {
+}
+
+export const AUTHSERVICE_JWT_PACKAGE_NAME = "authservice.jwt";
 
 export interface JwtServiceClient {
   createJwt(request: CreateJwtRequest): Observable<CreateJwtResponse>;
@@ -21,48 +33,26 @@ export interface JwtServiceClient {
 }
 
 export interface JwtServiceController {
-  createJwt(
-    request: CreateJwtRequest,
-  ):
-    | Promise<CreateJwtResponse>
-    | Observable<CreateJwtResponse>
-    | CreateJwtResponse;
+  createJwt(request: CreateJwtRequest): Promise<CreateJwtResponse> | Observable<CreateJwtResponse> | CreateJwtResponse;
 
   validateJwt(
     request: ValidateJwtRequest,
-  ):
-    | Promise<ValidateJwtResponse>
-    | Observable<ValidateJwtResponse>
-    | ValidateJwtResponse;
+  ): Promise<ValidateJwtResponse> | Observable<ValidateJwtResponse> | ValidateJwtResponse;
 }
 
 export function JwtServiceControllerMethods() {
   return function (constructor: Function) {
-    const grpcMethods: string[] = ['createJwt', 'validateJwt'];
+    const grpcMethods: string[] = ["createJwt", "validateJwt"];
     for (const method of grpcMethods) {
-      const descriptor: any = Reflect.getOwnPropertyDescriptor(
-        constructor.prototype,
-        method,
-      );
-      GrpcMethod('JwtService', method)(
-        constructor.prototype[method],
-        method,
-        descriptor,
-      );
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
+      GrpcMethod("JwtService", method)(constructor.prototype[method], method, descriptor);
     }
     const grpcStreamMethods: string[] = [];
     for (const method of grpcStreamMethods) {
-      const descriptor: any = Reflect.getOwnPropertyDescriptor(
-        constructor.prototype,
-        method,
-      );
-      GrpcStreamMethod('JwtService', method)(
-        constructor.prototype[method],
-        method,
-        descriptor,
-      );
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
+      GrpcStreamMethod("JwtService", method)(constructor.prototype[method], method, descriptor);
     }
   };
 }
 
-export const JWT_SERVICE_NAME = 'JwtService';
+export const JWT_SERVICE_NAME = "JwtService";

--- a/packages/api-gateway/src/auth-service/gen/jwt.ts
+++ b/packages/api-gateway/src/auth-service/gen/jwt.ts
@@ -1,8 +1,8 @@
 /* eslint-disable */
-import { GrpcMethod, GrpcStreamMethod } from "@nestjs/microservices";
-import { Observable } from "rxjs";
+import { GrpcMethod, GrpcStreamMethod } from '@nestjs/microservices';
+import { Observable } from 'rxjs';
 
-export const protobufPackage = "authservice.jwt";
+export const protobufPackage = 'authservice.jwt';
 
 export interface CreateJwtProjectInfo {
   hashedApiKey: string;
@@ -28,13 +28,11 @@ export interface CreateJwtResponse {
   jwt?: string | undefined;
 }
 
-export interface ValidateJwtRequest {
-}
+export interface ValidateJwtRequest {}
 
-export interface ValidateJwtResponse {
-}
+export interface ValidateJwtResponse {}
 
-export const AUTHSERVICE_JWT_PACKAGE_NAME = "authservice.jwt";
+export const AUTHSERVICE_JWT_PACKAGE_NAME = 'authservice.jwt';
 
 export interface JwtServiceClient {
   createJwt(request: CreateJwtRequest): Observable<CreateJwtResponse>;
@@ -43,32 +41,56 @@ export interface JwtServiceClient {
 }
 
 export interface JwtServiceController {
-  createJwt(request: CreateJwtRequest): Promise<CreateJwtResponse> | Observable<CreateJwtResponse> | CreateJwtResponse;
+  createJwt(
+    request: CreateJwtRequest,
+  ):
+    | Promise<CreateJwtResponse>
+    | Observable<CreateJwtResponse>
+    | CreateJwtResponse;
 
   validateJwt(
     request: ValidateJwtRequest,
-  ): Promise<ValidateJwtResponse> | Observable<ValidateJwtResponse> | ValidateJwtResponse;
+  ):
+    | Promise<ValidateJwtResponse>
+    | Observable<ValidateJwtResponse>
+    | ValidateJwtResponse;
 }
 
 export function JwtServiceControllerMethods() {
   return function (constructor: Function) {
-    const grpcMethods: string[] = ["createJwt", "validateJwt"];
+    const grpcMethods: string[] = ['createJwt', 'validateJwt'];
     for (const method of grpcMethods) {
-      const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
-      GrpcMethod("JwtService", method)(constructor.prototype[method], method, descriptor);
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(
+        constructor.prototype,
+        method,
+      );
+      GrpcMethod('JwtService', method)(
+        constructor.prototype[method],
+        method,
+        descriptor,
+      );
     }
     const grpcStreamMethods: string[] = [];
     for (const method of grpcStreamMethods) {
-      const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
-      GrpcStreamMethod("JwtService", method)(constructor.prototype[method], method, descriptor);
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(
+        constructor.prototype,
+        method,
+      );
+      GrpcStreamMethod('JwtService', method)(
+        constructor.prototype[method],
+        method,
+        descriptor,
+      );
     }
   };
 }
 
-export const JWT_SERVICE_NAME = "JwtService";
+export const JWT_SERVICE_NAME = 'JwtService';
 
 export interface InternalJwtServiceClient {
-  createJwtFromProjectInfo(request: CreateJwtProjectInfo): Observable<CreateJwtInfo>;
+  createJwtFromProjectInfo(
+    request: CreateJwtProjectInfo,
+  ): Observable<CreateJwtInfo>;
 }
 
 export interface InternalJwtServiceController {
@@ -79,17 +101,31 @@ export interface InternalJwtServiceController {
 
 export function InternalJwtServiceControllerMethods() {
   return function (constructor: Function) {
-    const grpcMethods: string[] = ["createJwtFromProjectInfo"];
+    const grpcMethods: string[] = ['createJwtFromProjectInfo'];
     for (const method of grpcMethods) {
-      const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
-      GrpcMethod("InternalJwtService", method)(constructor.prototype[method], method, descriptor);
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(
+        constructor.prototype,
+        method,
+      );
+      GrpcMethod('InternalJwtService', method)(
+        constructor.prototype[method],
+        method,
+        descriptor,
+      );
     }
     const grpcStreamMethods: string[] = [];
     for (const method of grpcStreamMethods) {
-      const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
-      GrpcStreamMethod("InternalJwtService", method)(constructor.prototype[method], method, descriptor);
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(
+        constructor.prototype,
+        method,
+      );
+      GrpcStreamMethod('InternalJwtService', method)(
+        constructor.prototype[method],
+        method,
+        descriptor,
+      );
     }
   };
 }
 
-export const INTERNAL_JWT_SERVICE_NAME = "InternalJwtService";
+export const INTERNAL_JWT_SERVICE_NAME = 'InternalJwtService';

--- a/packages/api-gateway/src/auth-service/gen/jwt.ts
+++ b/packages/api-gateway/src/auth-service/gen/jwt.ts
@@ -4,6 +4,16 @@ import { Observable } from "rxjs";
 
 export const protobufPackage = "authservice.jwt";
 
+export interface CreateJwtProjectInfo {
+  hashedApiKey: string;
+  projectId: string;
+  scopes: string[];
+}
+
+export interface CreateJwtInfo {
+  jwt: string;
+}
+
 export interface CreateJwtRequestHeader {
   XApiKey: string;
 }
@@ -14,7 +24,7 @@ export interface CreateJwtRequest {
 
 export interface CreateJwtResponse {
   success: boolean;
-  error: string;
+  error?: string | undefined;
   jwt?: string | undefined;
 }
 
@@ -56,3 +66,30 @@ export function JwtServiceControllerMethods() {
 }
 
 export const JWT_SERVICE_NAME = "JwtService";
+
+export interface InternalJwtServiceClient {
+  createJwtFromProjectInfo(request: CreateJwtProjectInfo): Observable<CreateJwtInfo>;
+}
+
+export interface InternalJwtServiceController {
+  createJwtFromProjectInfo(
+    request: CreateJwtProjectInfo,
+  ): Promise<CreateJwtInfo> | Observable<CreateJwtInfo> | CreateJwtInfo;
+}
+
+export function InternalJwtServiceControllerMethods() {
+  return function (constructor: Function) {
+    const grpcMethods: string[] = ["createJwtFromProjectInfo"];
+    for (const method of grpcMethods) {
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
+      GrpcMethod("InternalJwtService", method)(constructor.prototype[method], method, descriptor);
+    }
+    const grpcStreamMethods: string[] = [];
+    for (const method of grpcStreamMethods) {
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
+      GrpcStreamMethod("InternalJwtService", method)(constructor.prototype[method], method, descriptor);
+    }
+  };
+}
+
+export const INTERNAL_JWT_SERVICE_NAME = "InternalJwtService";

--- a/packages/api-gateway/src/auth-service/gen/jwt.ts
+++ b/packages/api-gateway/src/auth-service/gen/jwt.ts
@@ -10,6 +10,7 @@ export interface JwtForVerificationInfo {
 
 export interface VerificationInfo {
   verified: boolean;
+  hashedApiKey?: string | undefined;
 }
 
 export interface CreateJwtProjectInfo {

--- a/packages/api-gateway/src/auth-service/gen/jwt.ts
+++ b/packages/api-gateway/src/auth-service/gen/jwt.ts
@@ -4,6 +4,14 @@ import { Observable } from 'rxjs';
 
 export const protobufPackage = 'authservice.jwt';
 
+export interface JwtForVerificationInfo {
+  jwt: string;
+}
+
+export interface VerificationInfo {
+  verified: boolean;
+}
+
 export interface CreateJwtProjectInfo {
   hashedApiKey: string;
   projectId: string;
@@ -28,9 +36,19 @@ export interface CreateJwtResponse {
   jwt?: string | undefined;
 }
 
-export interface ValidateJwtRequest {}
+export interface ValidateJwtRequestHeader {
+  authorization: string;
+}
 
-export interface ValidateJwtResponse {}
+export interface ValidateJwtRequest {
+  header: ValidateJwtRequestHeader | undefined;
+}
+
+export interface ValidateJwtResponse {
+  success: boolean;
+  verified: boolean;
+  error?: string | undefined;
+}
 
 export const AUTHSERVICE_JWT_PACKAGE_NAME = 'authservice.jwt';
 
@@ -91,17 +109,26 @@ export interface InternalJwtServiceClient {
   createJwtFromProjectInfo(
     request: CreateJwtProjectInfo,
   ): Observable<CreateJwtInfo>;
+
+  verifyJwt(request: JwtForVerificationInfo): Observable<VerificationInfo>;
 }
 
 export interface InternalJwtServiceController {
   createJwtFromProjectInfo(
     request: CreateJwtProjectInfo,
   ): Promise<CreateJwtInfo> | Observable<CreateJwtInfo> | CreateJwtInfo;
+
+  verifyJwt(
+    request: JwtForVerificationInfo,
+  ):
+    | Promise<VerificationInfo>
+    | Observable<VerificationInfo>
+    | VerificationInfo;
 }
 
 export function InternalJwtServiceControllerMethods() {
   return function (constructor: Function) {
-    const grpcMethods: string[] = ['createJwtFromProjectInfo'];
+    const grpcMethods: string[] = ['createJwtFromProjectInfo', 'verifyJwt'];
     for (const method of grpcMethods) {
       const descriptor: any = Reflect.getOwnPropertyDescriptor(
         constructor.prototype,

--- a/packages/auth-service/package.json
+++ b/packages/auth-service/package.json
@@ -23,12 +23,12 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.9.7",
-    "jsonwebtoken": "^9.0.2",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.1.1",
     "@nestjs/core": "^10.0.0",
     "@nestjs/microservices": "^10.2.7",
     "@nestjs/platform-express": "^10.0.0",
+    "jsonwebtoken": "^9.0.2",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1"
   },

--- a/packages/auth-service/package.json
+++ b/packages/auth-service/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.9.7",
+    "jsonwebtoken": "^9.0.2",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.1.1",
     "@nestjs/core": "^10.0.0",

--- a/packages/auth-service/package.json
+++ b/packages/auth-service/package.json
@@ -39,6 +39,7 @@
     "@nestjs/testing": "^10.0.0",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",
+    "@types/jsonwebtoken": "^9.0.5",
     "@types/node": "^20.3.1",
     "@types/supertest": "^2.0.12",
     "@typescript-eslint/eslint-plugin": "^6.0.0",

--- a/packages/auth-service/src/gen/api_key.ts
+++ b/packages/auth-service/src/gen/api_key.ts
@@ -1,20 +1,16 @@
 /* eslint-disable */
-import { GrpcMethod, GrpcStreamMethod } from "@nestjs/microservices";
-import { Observable } from "rxjs";
+import { GrpcMethod, GrpcStreamMethod } from '@nestjs/microservices';
+import { Observable } from 'rxjs';
 
-export const protobufPackage = "authservice.api_key";
+export const protobufPackage = 'authservice.api_key';
 
-export interface IssueApiKeyRequest {
-}
+export interface IssueApiKeyRequest {}
 
-export interface IssueApiKeyResponse {
-}
+export interface IssueApiKeyResponse {}
 
-export interface RevokeApiKeyRequest {
-}
+export interface RevokeApiKeyRequest {}
 
-export interface RevokeApiKeyResponse {
-}
+export interface RevokeApiKeyResponse {}
 
 export interface GetProjectByApiKeyRequest {
   apiKey: string;
@@ -37,49 +33,84 @@ export interface GetHashedApiKeyResponse {
   error?: string | undefined;
 }
 
-export const AUTHSERVICE_API_KEY_PACKAGE_NAME = "authservice.api_key";
+export const AUTHSERVICE_API_KEY_PACKAGE_NAME = 'authservice.api_key';
 
 export interface ApiKeyServiceClient {
   issueApiKey(request: IssueApiKeyRequest): Observable<IssueApiKeyResponse>;
 
   revokeApiKey(request: RevokeApiKeyRequest): Observable<RevokeApiKeyResponse>;
 
-  getProjectByApiKey(request: GetProjectByApiKeyRequest): Observable<GetProjectByApiKeyResponse>;
+  getProjectByApiKey(
+    request: GetProjectByApiKeyRequest,
+  ): Observable<GetProjectByApiKeyResponse>;
 
-  getHashedApiKey(request: GetHashedApiKeyRequest): Observable<GetHashedApiKeyResponse>;
+  getHashedApiKey(
+    request: GetHashedApiKeyRequest,
+  ): Observable<GetHashedApiKeyResponse>;
 }
 
 export interface ApiKeyServiceController {
   issueApiKey(
     request: IssueApiKeyRequest,
-  ): Promise<IssueApiKeyResponse> | Observable<IssueApiKeyResponse> | IssueApiKeyResponse;
+  ):
+    | Promise<IssueApiKeyResponse>
+    | Observable<IssueApiKeyResponse>
+    | IssueApiKeyResponse;
 
   revokeApiKey(
     request: RevokeApiKeyRequest,
-  ): Promise<RevokeApiKeyResponse> | Observable<RevokeApiKeyResponse> | RevokeApiKeyResponse;
+  ):
+    | Promise<RevokeApiKeyResponse>
+    | Observable<RevokeApiKeyResponse>
+    | RevokeApiKeyResponse;
 
   getProjectByApiKey(
     request: GetProjectByApiKeyRequest,
-  ): Promise<GetProjectByApiKeyResponse> | Observable<GetProjectByApiKeyResponse> | GetProjectByApiKeyResponse;
+  ):
+    | Promise<GetProjectByApiKeyResponse>
+    | Observable<GetProjectByApiKeyResponse>
+    | GetProjectByApiKeyResponse;
 
   getHashedApiKey(
     request: GetHashedApiKeyRequest,
-  ): Promise<GetHashedApiKeyResponse> | Observable<GetHashedApiKeyResponse> | GetHashedApiKeyResponse;
+  ):
+    | Promise<GetHashedApiKeyResponse>
+    | Observable<GetHashedApiKeyResponse>
+    | GetHashedApiKeyResponse;
 }
 
 export function ApiKeyServiceControllerMethods() {
   return function (constructor: Function) {
-    const grpcMethods: string[] = ["issueApiKey", "revokeApiKey", "getProjectByApiKey", "getHashedApiKey"];
+    const grpcMethods: string[] = [
+      'issueApiKey',
+      'revokeApiKey',
+      'getProjectByApiKey',
+      'getHashedApiKey',
+    ];
     for (const method of grpcMethods) {
-      const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
-      GrpcMethod("ApiKeyService", method)(constructor.prototype[method], method, descriptor);
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(
+        constructor.prototype,
+        method,
+      );
+      GrpcMethod('ApiKeyService', method)(
+        constructor.prototype[method],
+        method,
+        descriptor,
+      );
     }
     const grpcStreamMethods: string[] = [];
     for (const method of grpcStreamMethods) {
-      const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
-      GrpcStreamMethod("ApiKeyService", method)(constructor.prototype[method], method, descriptor);
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(
+        constructor.prototype,
+        method,
+      );
+      GrpcStreamMethod('ApiKeyService', method)(
+        constructor.prototype[method],
+        method,
+        descriptor,
+      );
     }
   };
 }
 
-export const API_KEY_SERVICE_NAME = "ApiKeyService";
+export const API_KEY_SERVICE_NAME = 'ApiKeyService';

--- a/packages/auth-service/src/gen/api_key.ts
+++ b/packages/auth-service/src/gen/api_key.ts
@@ -1,68 +1,64 @@
 /* eslint-disable */
-import { GrpcMethod, GrpcStreamMethod } from '@nestjs/microservices';
-import { Observable } from 'rxjs';
+import { GrpcMethod, GrpcStreamMethod } from "@nestjs/microservices";
+import { Observable } from "rxjs";
 
-export const protobufPackage = 'authservice.api_key';
+export const protobufPackage = "authservice.api_key";
 
-export interface IssueApiKeyRequest {}
+export interface IssueApiKeyRequest {
+}
 
-export interface IssueApiKeyResponse {}
+export interface IssueApiKeyResponse {
+}
 
-export interface RevokeApiKeyRequest {}
+export interface RevokeApiKeyRequest {
+}
 
-export interface RevokeApiKeyResponse {}
+export interface RevokeApiKeyResponse {
+}
 
-export const AUTHSERVICE_API_KEY_PACKAGE_NAME = 'authservice.api_key';
+export interface IsValidApiKeyRequest {
+}
+
+export interface IsValidApiKeyResponse {
+}
+
+export const AUTHSERVICE_API_KEY_PACKAGE_NAME = "authservice.api_key";
 
 export interface ApiKeyServiceClient {
   issueApiKey(request: IssueApiKeyRequest): Observable<IssueApiKeyResponse>;
 
   revokeApiKey(request: RevokeApiKeyRequest): Observable<RevokeApiKeyResponse>;
+
+  isValidApiKey(request: IsValidApiKeyRequest): Observable<IsValidApiKeyResponse>;
 }
 
 export interface ApiKeyServiceController {
   issueApiKey(
     request: IssueApiKeyRequest,
-  ):
-    | Promise<IssueApiKeyResponse>
-    | Observable<IssueApiKeyResponse>
-    | IssueApiKeyResponse;
+  ): Promise<IssueApiKeyResponse> | Observable<IssueApiKeyResponse> | IssueApiKeyResponse;
 
   revokeApiKey(
     request: RevokeApiKeyRequest,
-  ):
-    | Promise<RevokeApiKeyResponse>
-    | Observable<RevokeApiKeyResponse>
-    | RevokeApiKeyResponse;
+  ): Promise<RevokeApiKeyResponse> | Observable<RevokeApiKeyResponse> | RevokeApiKeyResponse;
+
+  isValidApiKey(
+    request: IsValidApiKeyRequest,
+  ): Promise<IsValidApiKeyResponse> | Observable<IsValidApiKeyResponse> | IsValidApiKeyResponse;
 }
 
 export function ApiKeyServiceControllerMethods() {
   return function (constructor: Function) {
-    const grpcMethods: string[] = ['issueApiKey', 'revokeApiKey'];
+    const grpcMethods: string[] = ["issueApiKey", "revokeApiKey", "isValidApiKey"];
     for (const method of grpcMethods) {
-      const descriptor: any = Reflect.getOwnPropertyDescriptor(
-        constructor.prototype,
-        method,
-      );
-      GrpcMethod('ApiKeyService', method)(
-        constructor.prototype[method],
-        method,
-        descriptor,
-      );
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
+      GrpcMethod("ApiKeyService", method)(constructor.prototype[method], method, descriptor);
     }
     const grpcStreamMethods: string[] = [];
     for (const method of grpcStreamMethods) {
-      const descriptor: any = Reflect.getOwnPropertyDescriptor(
-        constructor.prototype,
-        method,
-      );
-      GrpcStreamMethod('ApiKeyService', method)(
-        constructor.prototype[method],
-        method,
-        descriptor,
-      );
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
+      GrpcStreamMethod("ApiKeyService", method)(constructor.prototype[method], method, descriptor);
     }
   };
 }
 
-export const API_KEY_SERVICE_NAME = 'ApiKeyService';
+export const API_KEY_SERVICE_NAME = "ApiKeyService";

--- a/packages/auth-service/src/gen/api_key.ts
+++ b/packages/auth-service/src/gen/api_key.ts
@@ -16,10 +16,25 @@ export interface RevokeApiKeyRequest {
 export interface RevokeApiKeyResponse {
 }
 
-export interface IsValidApiKeyRequest {
+export interface GetProjectByApiKeyRequest {
+  apiKey: string;
 }
 
-export interface IsValidApiKeyResponse {
+export interface GetProjectByApiKeyResponse {
+  success: boolean;
+  projectId?: string | undefined;
+  scopes: string[];
+  error?: string | undefined;
+}
+
+export interface GetHashedApiKeyRequest {
+  apiKey: string;
+}
+
+export interface GetHashedApiKeyResponse {
+  success: boolean;
+  hashedApiKey?: string | undefined;
+  error?: string | undefined;
 }
 
 export const AUTHSERVICE_API_KEY_PACKAGE_NAME = "authservice.api_key";
@@ -29,7 +44,9 @@ export interface ApiKeyServiceClient {
 
   revokeApiKey(request: RevokeApiKeyRequest): Observable<RevokeApiKeyResponse>;
 
-  isValidApiKey(request: IsValidApiKeyRequest): Observable<IsValidApiKeyResponse>;
+  getProjectByApiKey(request: GetProjectByApiKeyRequest): Observable<GetProjectByApiKeyResponse>;
+
+  getHashedApiKey(request: GetHashedApiKeyRequest): Observable<GetHashedApiKeyResponse>;
 }
 
 export interface ApiKeyServiceController {
@@ -41,14 +58,18 @@ export interface ApiKeyServiceController {
     request: RevokeApiKeyRequest,
   ): Promise<RevokeApiKeyResponse> | Observable<RevokeApiKeyResponse> | RevokeApiKeyResponse;
 
-  isValidApiKey(
-    request: IsValidApiKeyRequest,
-  ): Promise<IsValidApiKeyResponse> | Observable<IsValidApiKeyResponse> | IsValidApiKeyResponse;
+  getProjectByApiKey(
+    request: GetProjectByApiKeyRequest,
+  ): Promise<GetProjectByApiKeyResponse> | Observable<GetProjectByApiKeyResponse> | GetProjectByApiKeyResponse;
+
+  getHashedApiKey(
+    request: GetHashedApiKeyRequest,
+  ): Promise<GetHashedApiKeyResponse> | Observable<GetHashedApiKeyResponse> | GetHashedApiKeyResponse;
 }
 
 export function ApiKeyServiceControllerMethods() {
   return function (constructor: Function) {
-    const grpcMethods: string[] = ["issueApiKey", "revokeApiKey", "isValidApiKey"];
+    const grpcMethods: string[] = ["issueApiKey", "revokeApiKey", "getProjectByApiKey", "getHashedApiKey"];
     for (const method of grpcMethods) {
       const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
       GrpcMethod("ApiKeyService", method)(constructor.prototype[method], method, descriptor);

--- a/packages/auth-service/src/gen/api_key.ts
+++ b/packages/auth-service/src/gen/api_key.ts
@@ -33,6 +33,16 @@ export interface GetHashedApiKeyResponse {
   error?: string | undefined;
 }
 
+export interface ValidateHashedApiKeyRequest {
+  hashedApiKey: string;
+}
+
+export interface ValidateHashedApiKeyResponse {
+  success: boolean;
+  validHash: boolean;
+  error?: string | undefined;
+}
+
 export const AUTHSERVICE_API_KEY_PACKAGE_NAME = 'authservice.api_key';
 
 export interface ApiKeyServiceClient {
@@ -47,6 +57,10 @@ export interface ApiKeyServiceClient {
   getHashedApiKey(
     request: GetHashedApiKeyRequest,
   ): Observable<GetHashedApiKeyResponse>;
+
+  validateHashedApiKey(
+    request: ValidateHashedApiKeyRequest,
+  ): Observable<ValidateHashedApiKeyResponse>;
 }
 
 export interface ApiKeyServiceController {
@@ -77,6 +91,13 @@ export interface ApiKeyServiceController {
     | Promise<GetHashedApiKeyResponse>
     | Observable<GetHashedApiKeyResponse>
     | GetHashedApiKeyResponse;
+
+  validateHashedApiKey(
+    request: ValidateHashedApiKeyRequest,
+  ):
+    | Promise<ValidateHashedApiKeyResponse>
+    | Observable<ValidateHashedApiKeyResponse>
+    | ValidateHashedApiKeyResponse;
 }
 
 export function ApiKeyServiceControllerMethods() {
@@ -86,6 +107,7 @@ export function ApiKeyServiceControllerMethods() {
       'revokeApiKey',
       'getProjectByApiKey',
       'getHashedApiKey',
+      'validateHashedApiKey',
     ];
     for (const method of grpcMethods) {
       const descriptor: any = Reflect.getOwnPropertyDescriptor(

--- a/packages/auth-service/src/gen/jwt.ts
+++ b/packages/auth-service/src/gen/jwt.ts
@@ -1,18 +1,30 @@
 /* eslint-disable */
-import { GrpcMethod, GrpcStreamMethod } from '@nestjs/microservices';
-import { Observable } from 'rxjs';
+import { GrpcMethod, GrpcStreamMethod } from "@nestjs/microservices";
+import { Observable } from "rxjs";
 
-export const protobufPackage = 'authservice.jwt';
+export const protobufPackage = "authservice.jwt";
 
-export interface CreateJwtRequest {}
+export interface CreateJwtRequestHeader {
+  XApiKey: string;
+}
 
-export interface CreateJwtResponse {}
+export interface CreateJwtRequest {
+  header: CreateJwtRequestHeader | undefined;
+}
 
-export interface ValidateJwtRequest {}
+export interface CreateJwtResponse {
+  success: boolean;
+  error: string;
+  jwt?: string | undefined;
+}
 
-export interface ValidateJwtResponse {}
+export interface ValidateJwtRequest {
+}
 
-export const AUTHSERVICE_JWT_PACKAGE_NAME = 'authservice.jwt';
+export interface ValidateJwtResponse {
+}
+
+export const AUTHSERVICE_JWT_PACKAGE_NAME = "authservice.jwt";
 
 export interface JwtServiceClient {
   createJwt(request: CreateJwtRequest): Observable<CreateJwtResponse>;
@@ -21,48 +33,26 @@ export interface JwtServiceClient {
 }
 
 export interface JwtServiceController {
-  createJwt(
-    request: CreateJwtRequest,
-  ):
-    | Promise<CreateJwtResponse>
-    | Observable<CreateJwtResponse>
-    | CreateJwtResponse;
+  createJwt(request: CreateJwtRequest): Promise<CreateJwtResponse> | Observable<CreateJwtResponse> | CreateJwtResponse;
 
   validateJwt(
     request: ValidateJwtRequest,
-  ):
-    | Promise<ValidateJwtResponse>
-    | Observable<ValidateJwtResponse>
-    | ValidateJwtResponse;
+  ): Promise<ValidateJwtResponse> | Observable<ValidateJwtResponse> | ValidateJwtResponse;
 }
 
 export function JwtServiceControllerMethods() {
   return function (constructor: Function) {
-    const grpcMethods: string[] = ['createJwt', 'validateJwt'];
+    const grpcMethods: string[] = ["createJwt", "validateJwt"];
     for (const method of grpcMethods) {
-      const descriptor: any = Reflect.getOwnPropertyDescriptor(
-        constructor.prototype,
-        method,
-      );
-      GrpcMethod('JwtService', method)(
-        constructor.prototype[method],
-        method,
-        descriptor,
-      );
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
+      GrpcMethod("JwtService", method)(constructor.prototype[method], method, descriptor);
     }
     const grpcStreamMethods: string[] = [];
     for (const method of grpcStreamMethods) {
-      const descriptor: any = Reflect.getOwnPropertyDescriptor(
-        constructor.prototype,
-        method,
-      );
-      GrpcStreamMethod('JwtService', method)(
-        constructor.prototype[method],
-        method,
-        descriptor,
-      );
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
+      GrpcStreamMethod("JwtService", method)(constructor.prototype[method], method, descriptor);
     }
   };
 }
 
-export const JWT_SERVICE_NAME = 'JwtService';
+export const JWT_SERVICE_NAME = "JwtService";

--- a/packages/auth-service/src/gen/jwt.ts
+++ b/packages/auth-service/src/gen/jwt.ts
@@ -1,8 +1,8 @@
 /* eslint-disable */
-import { GrpcMethod, GrpcStreamMethod } from "@nestjs/microservices";
-import { Observable } from "rxjs";
+import { GrpcMethod, GrpcStreamMethod } from '@nestjs/microservices';
+import { Observable } from 'rxjs';
 
-export const protobufPackage = "authservice.jwt";
+export const protobufPackage = 'authservice.jwt';
 
 export interface CreateJwtProjectInfo {
   hashedApiKey: string;
@@ -28,13 +28,11 @@ export interface CreateJwtResponse {
   jwt?: string | undefined;
 }
 
-export interface ValidateJwtRequest {
-}
+export interface ValidateJwtRequest {}
 
-export interface ValidateJwtResponse {
-}
+export interface ValidateJwtResponse {}
 
-export const AUTHSERVICE_JWT_PACKAGE_NAME = "authservice.jwt";
+export const AUTHSERVICE_JWT_PACKAGE_NAME = 'authservice.jwt';
 
 export interface JwtServiceClient {
   createJwt(request: CreateJwtRequest): Observable<CreateJwtResponse>;
@@ -43,32 +41,56 @@ export interface JwtServiceClient {
 }
 
 export interface JwtServiceController {
-  createJwt(request: CreateJwtRequest): Promise<CreateJwtResponse> | Observable<CreateJwtResponse> | CreateJwtResponse;
+  createJwt(
+    request: CreateJwtRequest,
+  ):
+    | Promise<CreateJwtResponse>
+    | Observable<CreateJwtResponse>
+    | CreateJwtResponse;
 
   validateJwt(
     request: ValidateJwtRequest,
-  ): Promise<ValidateJwtResponse> | Observable<ValidateJwtResponse> | ValidateJwtResponse;
+  ):
+    | Promise<ValidateJwtResponse>
+    | Observable<ValidateJwtResponse>
+    | ValidateJwtResponse;
 }
 
 export function JwtServiceControllerMethods() {
   return function (constructor: Function) {
-    const grpcMethods: string[] = ["createJwt", "validateJwt"];
+    const grpcMethods: string[] = ['createJwt', 'validateJwt'];
     for (const method of grpcMethods) {
-      const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
-      GrpcMethod("JwtService", method)(constructor.prototype[method], method, descriptor);
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(
+        constructor.prototype,
+        method,
+      );
+      GrpcMethod('JwtService', method)(
+        constructor.prototype[method],
+        method,
+        descriptor,
+      );
     }
     const grpcStreamMethods: string[] = [];
     for (const method of grpcStreamMethods) {
-      const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
-      GrpcStreamMethod("JwtService", method)(constructor.prototype[method], method, descriptor);
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(
+        constructor.prototype,
+        method,
+      );
+      GrpcStreamMethod('JwtService', method)(
+        constructor.prototype[method],
+        method,
+        descriptor,
+      );
     }
   };
 }
 
-export const JWT_SERVICE_NAME = "JwtService";
+export const JWT_SERVICE_NAME = 'JwtService';
 
 export interface InternalJwtServiceClient {
-  createJwtFromProjectInfo(request: CreateJwtProjectInfo): Observable<CreateJwtInfo>;
+  createJwtFromProjectInfo(
+    request: CreateJwtProjectInfo,
+  ): Observable<CreateJwtInfo>;
 }
 
 export interface InternalJwtServiceController {
@@ -79,17 +101,31 @@ export interface InternalJwtServiceController {
 
 export function InternalJwtServiceControllerMethods() {
   return function (constructor: Function) {
-    const grpcMethods: string[] = ["createJwtFromProjectInfo"];
+    const grpcMethods: string[] = ['createJwtFromProjectInfo'];
     for (const method of grpcMethods) {
-      const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
-      GrpcMethod("InternalJwtService", method)(constructor.prototype[method], method, descriptor);
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(
+        constructor.prototype,
+        method,
+      );
+      GrpcMethod('InternalJwtService', method)(
+        constructor.prototype[method],
+        method,
+        descriptor,
+      );
     }
     const grpcStreamMethods: string[] = [];
     for (const method of grpcStreamMethods) {
-      const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
-      GrpcStreamMethod("InternalJwtService", method)(constructor.prototype[method], method, descriptor);
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(
+        constructor.prototype,
+        method,
+      );
+      GrpcStreamMethod('InternalJwtService', method)(
+        constructor.prototype[method],
+        method,
+        descriptor,
+      );
     }
   };
 }
 
-export const INTERNAL_JWT_SERVICE_NAME = "InternalJwtService";
+export const INTERNAL_JWT_SERVICE_NAME = 'InternalJwtService';

--- a/packages/auth-service/src/gen/jwt.ts
+++ b/packages/auth-service/src/gen/jwt.ts
@@ -4,6 +4,16 @@ import { Observable } from "rxjs";
 
 export const protobufPackage = "authservice.jwt";
 
+export interface CreateJwtProjectInfo {
+  hashedApiKey: string;
+  projectId: string;
+  scopes: string[];
+}
+
+export interface CreateJwtInfo {
+  jwt: string;
+}
+
 export interface CreateJwtRequestHeader {
   XApiKey: string;
 }
@@ -14,7 +24,7 @@ export interface CreateJwtRequest {
 
 export interface CreateJwtResponse {
   success: boolean;
-  error: string;
+  error?: string | undefined;
   jwt?: string | undefined;
 }
 
@@ -56,3 +66,30 @@ export function JwtServiceControllerMethods() {
 }
 
 export const JWT_SERVICE_NAME = "JwtService";
+
+export interface InternalJwtServiceClient {
+  createJwtFromProjectInfo(request: CreateJwtProjectInfo): Observable<CreateJwtInfo>;
+}
+
+export interface InternalJwtServiceController {
+  createJwtFromProjectInfo(
+    request: CreateJwtProjectInfo,
+  ): Promise<CreateJwtInfo> | Observable<CreateJwtInfo> | CreateJwtInfo;
+}
+
+export function InternalJwtServiceControllerMethods() {
+  return function (constructor: Function) {
+    const grpcMethods: string[] = ["createJwtFromProjectInfo"];
+    for (const method of grpcMethods) {
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
+      GrpcMethod("InternalJwtService", method)(constructor.prototype[method], method, descriptor);
+    }
+    const grpcStreamMethods: string[] = [];
+    for (const method of grpcStreamMethods) {
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
+      GrpcStreamMethod("InternalJwtService", method)(constructor.prototype[method], method, descriptor);
+    }
+  };
+}
+
+export const INTERNAL_JWT_SERVICE_NAME = "InternalJwtService";

--- a/packages/auth-service/src/gen/jwt.ts
+++ b/packages/auth-service/src/gen/jwt.ts
@@ -10,6 +10,7 @@ export interface JwtForVerificationInfo {
 
 export interface VerificationInfo {
   verified: boolean;
+  hashedApiKey?: string | undefined;
 }
 
 export interface CreateJwtProjectInfo {

--- a/packages/auth-service/src/gen/jwt.ts
+++ b/packages/auth-service/src/gen/jwt.ts
@@ -4,6 +4,14 @@ import { Observable } from 'rxjs';
 
 export const protobufPackage = 'authservice.jwt';
 
+export interface JwtForVerificationInfo {
+  jwt: string;
+}
+
+export interface VerificationInfo {
+  verified: boolean;
+}
+
 export interface CreateJwtProjectInfo {
   hashedApiKey: string;
   projectId: string;
@@ -28,9 +36,19 @@ export interface CreateJwtResponse {
   jwt?: string | undefined;
 }
 
-export interface ValidateJwtRequest {}
+export interface ValidateJwtRequestHeader {
+  authorization: string;
+}
 
-export interface ValidateJwtResponse {}
+export interface ValidateJwtRequest {
+  header: ValidateJwtRequestHeader | undefined;
+}
+
+export interface ValidateJwtResponse {
+  success: boolean;
+  verified: boolean;
+  error?: string | undefined;
+}
 
 export const AUTHSERVICE_JWT_PACKAGE_NAME = 'authservice.jwt';
 
@@ -91,17 +109,26 @@ export interface InternalJwtServiceClient {
   createJwtFromProjectInfo(
     request: CreateJwtProjectInfo,
   ): Observable<CreateJwtInfo>;
+
+  verifyJwt(request: JwtForVerificationInfo): Observable<VerificationInfo>;
 }
 
 export interface InternalJwtServiceController {
   createJwtFromProjectInfo(
     request: CreateJwtProjectInfo,
   ): Promise<CreateJwtInfo> | Observable<CreateJwtInfo> | CreateJwtInfo;
+
+  verifyJwt(
+    request: JwtForVerificationInfo,
+  ):
+    | Promise<VerificationInfo>
+    | Observable<VerificationInfo>
+    | VerificationInfo;
 }
 
 export function InternalJwtServiceControllerMethods() {
   return function (constructor: Function) {
-    const grpcMethods: string[] = ['createJwtFromProjectInfo'];
+    const grpcMethods: string[] = ['createJwtFromProjectInfo', 'verifyJwt'];
     for (const method of grpcMethods) {
       const descriptor: any = Reflect.getOwnPropertyDescriptor(
         constructor.prototype,

--- a/packages/auth-service/src/modules/api_key/api_key.controller.ts
+++ b/packages/auth-service/src/modules/api_key/api_key.controller.ts
@@ -10,6 +10,8 @@ import {
   IssueApiKeyResponse,
   RevokeApiKeyRequest,
   RevokeApiKeyResponse,
+  ValidateHashedApiKeyRequest,
+  ValidateHashedApiKeyResponse,
 } from 'src/gen/api_key';
 
 @Controller('api_key')
@@ -43,6 +45,17 @@ export class ApiKeyController implements ApiKeyServiceController {
     return {
       success: true,
       hashedApiKey: request.apiKey,
+    };
+  }
+
+  async validateHashedApiKey(
+    request: ValidateHashedApiKeyRequest,
+  ): Promise<ValidateHashedApiKeyResponse> {
+    const { hashedApiKey } = request;
+
+    return {
+      success: true,
+      validHash: hashedApiKey !== '',
     };
   }
 }

--- a/packages/auth-service/src/modules/api_key/api_key.controller.ts
+++ b/packages/auth-service/src/modules/api_key/api_key.controller.ts
@@ -2,8 +2,10 @@ import { Controller } from '@nestjs/common';
 import {
   ApiKeyServiceController,
   ApiKeyServiceControllerMethods,
-  IsValidApiKeyRequest,
-  IsValidApiKeyResponse,
+  GetHashedApiKeyRequest,
+  GetHashedApiKeyResponse,
+  GetProjectByApiKeyRequest,
+  GetProjectByApiKeyResponse,
   IssueApiKeyRequest,
   IssueApiKeyResponse,
   RevokeApiKeyRequest,
@@ -22,8 +24,22 @@ export class ApiKeyController implements ApiKeyServiceController {
     throw new Error('Method not implemented.');
   }
 
-  async isValidApiKey(request: IsValidApiKeyRequest): Promise<IsValidApiKeyResponse> {
+  async getProjectByApiKey(request: GetProjectByApiKeyRequest): Promise<GetProjectByApiKeyResponse> {
+    const apiKey = request.apiKey;
 
-    return true
+    return {
+      success: false,
+      projectId: null,
+      scopes: [],
+      error: `Failed to retrieve project with api key ${apiKey}`
+    }
   }
+
+  async getHashedApiKey(request: GetHashedApiKeyRequest): Promise<GetHashedApiKeyResponse> {
+    return {
+      success: true,
+      hashedApiKey: "hello world"
+    }
+  }
+
 }

--- a/packages/auth-service/src/modules/api_key/api_key.controller.ts
+++ b/packages/auth-service/src/modules/api_key/api_key.controller.ts
@@ -42,7 +42,7 @@ export class ApiKeyController implements ApiKeyServiceController {
   ): Promise<GetHashedApiKeyResponse> {
     return {
       success: true,
-      hashedApiKey: 'hello world',
+      hashedApiKey: request.apiKey,
     };
   }
 }

--- a/packages/auth-service/src/modules/api_key/api_key.controller.ts
+++ b/packages/auth-service/src/modules/api_key/api_key.controller.ts
@@ -24,22 +24,25 @@ export class ApiKeyController implements ApiKeyServiceController {
     throw new Error('Method not implemented.');
   }
 
-  async getProjectByApiKey(request: GetProjectByApiKeyRequest): Promise<GetProjectByApiKeyResponse> {
+  async getProjectByApiKey(
+    request: GetProjectByApiKeyRequest,
+  ): Promise<GetProjectByApiKeyResponse> {
     const apiKey = request.apiKey;
 
     return {
       success: false,
       projectId: null,
       scopes: [],
-      error: `Failed to retrieve project with api key ${apiKey}`
-    }
+      error: `Failed to retrieve project with api key ${apiKey}`,
+    };
   }
 
-  async getHashedApiKey(request: GetHashedApiKeyRequest): Promise<GetHashedApiKeyResponse> {
+  async getHashedApiKey(
+    request: GetHashedApiKeyRequest,
+  ): Promise<GetHashedApiKeyResponse> {
     return {
       success: true,
-      hashedApiKey: "hello world"
-    }
+      hashedApiKey: 'hello world',
+    };
   }
-
 }

--- a/packages/auth-service/src/modules/api_key/api_key.controller.ts
+++ b/packages/auth-service/src/modules/api_key/api_key.controller.ts
@@ -2,6 +2,8 @@ import { Controller } from '@nestjs/common';
 import {
   ApiKeyServiceController,
   ApiKeyServiceControllerMethods,
+  IsValidApiKeyRequest,
+  IsValidApiKeyResponse,
   IssueApiKeyRequest,
   IssueApiKeyResponse,
   RevokeApiKeyRequest,
@@ -18,5 +20,10 @@ export class ApiKeyController implements ApiKeyServiceController {
   revokeApiKey(request: RevokeApiKeyRequest): Promise<RevokeApiKeyResponse> {
     console.log(`request: ${request}`);
     throw new Error('Method not implemented.');
+  }
+
+  async isValidApiKey(request: IsValidApiKeyRequest): Promise<IsValidApiKeyResponse> {
+
+    return true
   }
 }

--- a/packages/auth-service/src/modules/jwt/jwt.controller.ts
+++ b/packages/auth-service/src/modules/jwt/jwt.controller.ts
@@ -51,7 +51,7 @@ export class JWTController implements JwtServiceController, OnModuleInit {
       this.apiKeyService.getHashedApiKey({ apiKey }),
     );
 
-    const jwt = this.jwtService.createJwtFromProjectInfo({
+    const { jwt } = this.jwtService.createJwtFromProjectInfo({
       projectId: project.projectId,
       scopes: project.scopes,
       hashedApiKey,
@@ -59,6 +59,7 @@ export class JWTController implements JwtServiceController, OnModuleInit {
 
     return {
       success: true,
+      jwt,
     };
   }
   validateJwt(request: ValidateJwtRequest): Promise<ValidateJwtResponse> {

--- a/packages/auth-service/src/modules/jwt/jwt.controller.ts
+++ b/packages/auth-service/src/modules/jwt/jwt.controller.ts
@@ -1,7 +1,10 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Inject, Post } from '@nestjs/common';
+import { ClientGrpc } from '@nestjs/microservices';
+import { API_KEY_SERVICE_NAME, ApiKeyServiceClient } from 'src/gen/api_key';
 import {
   CreateJwtRequest,
   CreateJwtResponse,
+  JWT_SERVICE_NAME,
   JwtServiceController,
   JwtServiceControllerMethods,
   ValidateJwtRequest,
@@ -11,9 +14,25 @@ import {
 @Controller('jwt')
 @JwtServiceControllerMethods()
 export class JWTController implements JwtServiceController {
+  private apiKeyService: ApiKeyServiceClient;
+
+  constructor(private apiKeyClient: ClientGrpc) {
+    this.apiKeyService = apiKeyClient.getService<ApiKeyServiceClient>(API_KEY_SERVICE_NAME);
+  }
+
+  @Post('authorize')
   async createJwt(request: CreateJwtRequest): Promise<CreateJwtResponse> {
-    console.log(`request: ${request}`);
-    return {};
+    const { header } = request;
+    const apiKey = header.XApiKey;
+
+    if (!this.apiKeyService.isValidApiKey(apiKey)) {
+      return {
+        success: false,
+        error: "Provided API key is not valid"
+      }
+    }
+
+    return
   }
   validateJwt(request: ValidateJwtRequest): Promise<ValidateJwtResponse> {
     console.log(`request: ${request}`);

--- a/packages/auth-service/src/modules/jwt/jwt.controller.ts
+++ b/packages/auth-service/src/modules/jwt/jwt.controller.ts
@@ -2,7 +2,6 @@ import {
   Controller,
   Inject,
   OnModuleInit,
-  Post,
   UnauthorizedException,
 } from '@nestjs/common';
 import { ClientGrpc } from '@nestjs/microservices';
@@ -37,7 +36,6 @@ export class JWTController implements JwtServiceController, OnModuleInit {
       this.apiKeyClient.getService<ApiKeyServiceClient>(API_KEY_SERVICE_NAME);
   }
 
-  @Post('authorize')
   async createJwt(request: CreateJwtRequest): Promise<CreateJwtResponse> {
     const { header } = request;
     const apiKey = header.XApiKey;
@@ -46,7 +44,7 @@ export class JWTController implements JwtServiceController, OnModuleInit {
       this.apiKeyService.getProjectByApiKey({ apiKey }),
     );
 
-    if (project.success) {
+    if (!project.success) {
       return {
         success: false,
         error: 'Provided API key is not valid',

--- a/packages/auth-service/src/modules/jwt/jwt.controller.ts
+++ b/packages/auth-service/src/modules/jwt/jwt.controller.ts
@@ -62,8 +62,27 @@ export class JWTController implements JwtServiceController, OnModuleInit {
       jwt,
     };
   }
-  validateJwt(request: ValidateJwtRequest): Promise<ValidateJwtResponse> {
-    console.log(`request: ${request}`);
-    throw new Error('Method not implemented.');
+
+  async validateJwt(request: ValidateJwtRequest): Promise<ValidateJwtResponse> {
+    const { header } = request;
+    const authorization = header.authorization.split(' ');
+
+    if (
+      !authorization ||
+      authorization[0] !== 'Bearer' ||
+      authorization.length !== 2
+    ) {
+      return {
+        success: false,
+        verified: false,
+        error: 'Unauthorized',
+      };
+    }
+    const { verified } = this.jwtService.verifyJwt({ jwt: authorization[1] });
+
+    return {
+      success: true,
+      verified,
+    };
   }
 }

--- a/packages/auth-service/src/modules/jwt/jwt.controller.ts
+++ b/packages/auth-service/src/modules/jwt/jwt.controller.ts
@@ -1,6 +1,10 @@
 import { Controller, Inject, OnModuleInit, Post } from '@nestjs/common';
 import { ClientGrpc } from '@nestjs/microservices';
-import { API_KEY_SERVICE_NAME, ApiKeyServiceClient, GetProjectByApiKeyResponse } from 'src/gen/api_key';
+import {
+  API_KEY_SERVICE_NAME,
+  ApiKeyServiceClient,
+  GetProjectByApiKeyResponse,
+} from 'src/gen/api_key';
 import {
   CreateJwtRequest,
   CreateJwtResponse,
@@ -19,11 +23,12 @@ export class JWTController implements JwtServiceController, OnModuleInit {
 
   constructor(
     private readonly jwtService: JWTService,
-    @Inject(API_KEY_SERVICE_NAME) private apiKeyClient: ClientGrpc
-  ) { }
+    @Inject(API_KEY_SERVICE_NAME) private apiKeyClient: ClientGrpc,
+  ) {}
 
   onModuleInit() {
-    this.apiKeyService = this.apiKeyClient.getService<ApiKeyServiceClient>(API_KEY_SERVICE_NAME);
+    this.apiKeyService =
+      this.apiKeyClient.getService<ApiKeyServiceClient>(API_KEY_SERVICE_NAME);
   }
 
   @Post('authorize')
@@ -31,27 +36,30 @@ export class JWTController implements JwtServiceController, OnModuleInit {
     const { header } = request;
     const apiKey = header.XApiKey;
 
-    const project: GetProjectByApiKeyResponse = await lastValueFrom(this.apiKeyService.getProjectByApiKey({ apiKey }));
+    const project: GetProjectByApiKeyResponse = await lastValueFrom(
+      this.apiKeyService.getProjectByApiKey({ apiKey }),
+    );
 
     if (project.success) {
       return {
         success: false,
-        error: "Provided API key is not valid"
-      }
+        error: 'Provided API key is not valid',
+      };
     }
 
-    const { hashedApiKey } = await lastValueFrom(this.apiKeyService.getHashedApiKey({ apiKey }));
+    const { hashedApiKey } = await lastValueFrom(
+      this.apiKeyService.getHashedApiKey({ apiKey }),
+    );
 
     const jwt = this.jwtService.createJwtFromProjectInfo({
       projectId: project.projectId,
       scopes: project.scopes,
-      hashedApiKey
+      hashedApiKey,
     });
 
     return {
       success: true,
-
-    }
+    };
   }
   validateJwt(request: ValidateJwtRequest): Promise<ValidateJwtResponse> {
     console.log(`request: ${request}`);

--- a/packages/auth-service/src/modules/jwt/jwt.module.ts
+++ b/packages/auth-service/src/modules/jwt/jwt.module.ts
@@ -4,7 +4,10 @@ import { JWTService } from './jwt.service';
 import { ConfigModule } from '@nestjs/config';
 import { join } from 'path';
 import { ClientsModule, Transport } from '@nestjs/microservices';
-import { API_KEY_SERVICE_NAME, AUTHSERVICE_API_KEY_PACKAGE_NAME } from 'src/gen/api_key';
+import {
+  API_KEY_SERVICE_NAME,
+  AUTHSERVICE_API_KEY_PACKAGE_NAME,
+} from 'src/gen/api_key';
 
 @Module({
   imports: [
@@ -23,9 +26,10 @@ import { API_KEY_SERVICE_NAME, AUTHSERVICE_API_KEY_PACKAGE_NAME } from 'src/gen/
             '../../../../proto/auth-service/api_key.proto',
           ),
         },
-      }])
+      },
+    ]),
   ],
   controllers: [JWTController],
   providers: [JWTService],
 })
-export class JwtModule { }
+export class JwtModule {}

--- a/packages/auth-service/src/modules/jwt/jwt.module.ts
+++ b/packages/auth-service/src/modules/jwt/jwt.module.ts
@@ -1,7 +1,31 @@
 import { Module } from '@nestjs/common';
 import { JWTController } from './jwt.controller';
+import { JWTService } from './jwt.service';
+import { ConfigModule } from '@nestjs/config';
+import { join } from 'path';
+import { ClientsModule, Transport } from '@nestjs/microservices';
+import { API_KEY_SERVICE_NAME, AUTHSERVICE_API_KEY_PACKAGE_NAME } from 'src/gen/api_key';
 
 @Module({
+  imports: [
+    ConfigModule.forRoot({
+      envFilePath: join(__dirname, '../../../../.env.local'),
+    }),
+    ClientsModule.register([
+      {
+        name: API_KEY_SERVICE_NAME,
+        transport: Transport.GRPC,
+        options: {
+          url: process.env.AUTH_SERVICE_ADDR,
+          package: AUTHSERVICE_API_KEY_PACKAGE_NAME,
+          protoPath: join(
+            __dirname,
+            '../../../../proto/auth-service/api_key.proto',
+          ),
+        },
+      }])
+  ],
   controllers: [JWTController],
+  providers: [JWTService],
 })
-export class JwtModule {}
+export class JwtModule { }

--- a/packages/auth-service/src/modules/jwt/jwt.service.ts
+++ b/packages/auth-service/src/modules/jwt/jwt.service.ts
@@ -3,6 +3,8 @@ import {
   CreateJwtInfo,
   CreateJwtProjectInfo,
   InternalJwtServiceController,
+  JwtForVerificationInfo,
+  VerificationInfo,
 } from 'src/gen/jwt';
 import jwt from 'jsonwebtoken';
 
@@ -23,6 +25,15 @@ export class JWTService implements InternalJwtServiceController {
 
     return {
       jwt: token,
+    };
+  }
+
+  verifyJwt(jwtInfo: JwtForVerificationInfo): VerificationInfo {
+    const token = jwtInfo.jwt;
+    jwt.verify(token, process.env.JWT_SECRET ?? 'secret');
+
+    return {
+      verified: true,
     };
   }
 }

--- a/packages/auth-service/src/modules/jwt/jwt.service.ts
+++ b/packages/auth-service/src/modules/jwt/jwt.service.ts
@@ -36,11 +36,10 @@ export class JWTService implements InternalJwtServiceController {
       return {
         verified: true,
       };
-
     } catch {
       return {
-        verified: false
-      }
+        verified: false,
+      };
     }
   }
 }

--- a/packages/auth-service/src/modules/jwt/jwt.service.ts
+++ b/packages/auth-service/src/modules/jwt/jwt.service.ts
@@ -1,21 +1,28 @@
 import { Injectable } from '@nestjs/common';
-import { CreateJwtInfo, CreateJwtProjectInfo, InternalJwtServiceController } from 'src/gen/jwt';
-import jwt from "jsonwebtoken";
+import {
+  CreateJwtInfo,
+  CreateJwtProjectInfo,
+  InternalJwtServiceController,
+} from 'src/gen/jwt';
+import jwt from 'jsonwebtoken';
 
 @Injectable()
 export class JWTService implements InternalJwtServiceController {
-    createJwtFromProjectInfo(projectInfo: CreateJwtProjectInfo): CreateJwtInfo {
-        const { projectId, scopes, hashedApiKey } = projectInfo;
+  createJwtFromProjectInfo(projectInfo: CreateJwtProjectInfo): CreateJwtInfo {
+    const { projectId, scopes, hashedApiKey } = projectInfo;
 
-        const token = jwt.sign({
-            projectId,
-            hashedApiKey,
-            scopes
-        }, process.env.JWT_SECRET ?? "secret", { expiresIn: '1h' })
+    const token = jwt.sign(
+      {
+        projectId,
+        hashedApiKey,
+        scopes,
+      },
+      process.env.JWT_SECRET ?? 'secret',
+      { expiresIn: '1h' },
+    );
 
-        return {
-            jwt: token
-        }
-    }
-
+    return {
+      jwt: token,
+    };
+  }
 }

--- a/packages/auth-service/src/modules/jwt/jwt.service.ts
+++ b/packages/auth-service/src/modules/jwt/jwt.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { CreateJwtInfo, CreateJwtProjectInfo, InternalJwtServiceController } from 'src/gen/jwt';
+import jwt from "jsonwebtoken";
+
+@Injectable()
+export class JWTService implements InternalJwtServiceController {
+    createJwtFromProjectInfo(projectInfo: CreateJwtProjectInfo): CreateJwtInfo {
+        const { projectId, scopes, hashedApiKey } = projectInfo;
+
+        const token = jwt.sign({
+            projectId,
+            hashedApiKey,
+            scopes
+        }, process.env.JWT_SECRET ?? "secret", { expiresIn: '1h' })
+
+        return {
+            jwt: token
+        }
+    }
+
+}

--- a/packages/auth-service/src/modules/jwt/jwt.service.ts
+++ b/packages/auth-service/src/modules/jwt/jwt.service.ts
@@ -11,17 +11,9 @@ import jwt from 'jsonwebtoken';
 @Injectable()
 export class JWTService implements InternalJwtServiceController {
   createJwtFromProjectInfo(projectInfo: CreateJwtProjectInfo): CreateJwtInfo {
-    const { projectId, scopes, hashedApiKey } = projectInfo;
-
-    const token = jwt.sign(
-      {
-        projectId,
-        hashedApiKey,
-        scopes,
-      },
-      process.env.JWT_SECRET ?? 'secret',
-      { expiresIn: '1h' },
-    );
+    const token = jwt.sign(projectInfo, process.env.JWT_SECRET ?? 'secret', {
+      expiresIn: '1h',
+    });
 
     return {
       jwt: token,
@@ -31,10 +23,14 @@ export class JWTService implements InternalJwtServiceController {
   verifyJwt(jwtInfo: JwtForVerificationInfo): VerificationInfo {
     try {
       const token = jwtInfo.jwt;
-      jwt.verify(token, process.env.JWT_SECRET ?? 'secret');
+      const tokenData: CreateJwtProjectInfo = jwt.verify(
+        token,
+        process.env.JWT_SECRET ?? 'secret',
+      );
 
       return {
         verified: true,
+        hashedApiKey: tokenData.hashedApiKey,
       };
     } catch {
       return {

--- a/packages/auth-service/src/modules/jwt/jwt.service.ts
+++ b/packages/auth-service/src/modules/jwt/jwt.service.ts
@@ -6,7 +6,9 @@ import {
   JwtForVerificationInfo,
   VerificationInfo,
 } from 'src/gen/jwt';
-import jwt from 'jsonwebtoken';
+import jwt, { JwtPayload } from 'jsonwebtoken';
+
+type JunoJwtPayload = JwtPayload & CreateJwtProjectInfo;
 
 @Injectable()
 export class JWTService implements InternalJwtServiceController {
@@ -23,9 +25,8 @@ export class JWTService implements InternalJwtServiceController {
   verifyJwt(jwtInfo: JwtForVerificationInfo): VerificationInfo {
     try {
       const token = jwtInfo.jwt;
-      const tokenData: CreateJwtProjectInfo = jwt.verify(
-        token,
-        process.env.JWT_SECRET ?? 'secret',
+      const tokenData: CreateJwtProjectInfo = <JunoJwtPayload>(
+        jwt.verify(token, process.env.JWT_SECRET ?? 'secret')
       );
 
       return {

--- a/packages/auth-service/src/modules/jwt/jwt.service.ts
+++ b/packages/auth-service/src/modules/jwt/jwt.service.ts
@@ -29,11 +29,18 @@ export class JWTService implements InternalJwtServiceController {
   }
 
   verifyJwt(jwtInfo: JwtForVerificationInfo): VerificationInfo {
-    const token = jwtInfo.jwt;
-    jwt.verify(token, process.env.JWT_SECRET ?? 'secret');
+    try {
+      const token = jwtInfo.jwt;
+      jwt.verify(token, process.env.JWT_SECRET ?? 'secret');
 
-    return {
-      verified: true,
-    };
+      return {
+        verified: true,
+      };
+
+    } catch {
+      return {
+        verified: false
+      }
+    }
   }
 }

--- a/packages/proto/auth-service/api_key.proto
+++ b/packages/proto/auth-service/api_key.proto
@@ -5,7 +5,8 @@ package authservice.api_key;
 service ApiKeyService {
   rpc issueApiKey(IssueApiKeyRequest) returns (IssueApiKeyResponse);
   rpc revokeApiKey(RevokeApiKeyRequest) returns (RevokeApiKeyResponse);
-  rpc isValidApiKey(IsValidApiKeyRequest) returns (IsValidApiKeyResponse);
+  rpc getProjectByApiKey(GetProjectByApiKeyRequest) returns (GetProjectByApiKeyResponse);
+  rpc getHashedApiKey(GetHashedApiKeyRequest) returns (GetHashedApiKeyResponse);
 }
 
 message IssueApiKeyRequest {}
@@ -14,5 +15,34 @@ message IssueApiKeyResponse {}
 message RevokeApiKeyRequest {}
 message RevokeApiKeyResponse {}
 
-message IsValidApiKeyRequest{}
-message IsValidApiKeyResponse{}
+message GetProjectByApiKeyRequest{
+  string apiKey = 1;
+}
+message GetProjectByApiKeyResponse{
+  bool success = 1;
+  oneof project_id_optional{
+    string projectId = 2;
+  }
+  
+  repeated string scopes = 3;
+
+  oneof error_optional{
+    string error = 4;
+  }
+
+}
+
+message GetHashedApiKeyRequest{
+  string apiKey = 1;
+}
+message GetHashedApiKeyResponse{
+  bool success = 1;
+  oneof hashed_api_key_optional{
+    string hashedApiKey = 2;
+  }
+  
+  oneof error_optional{
+    string error = 3;
+  }
+
+}

--- a/packages/proto/auth-service/api_key.proto
+++ b/packages/proto/auth-service/api_key.proto
@@ -7,6 +7,8 @@ service ApiKeyService {
   rpc revokeApiKey(RevokeApiKeyRequest) returns (RevokeApiKeyResponse);
   rpc getProjectByApiKey(GetProjectByApiKeyRequest) returns (GetProjectByApiKeyResponse);
   rpc getHashedApiKey(GetHashedApiKeyRequest) returns (GetHashedApiKeyResponse);
+  rpc validateHashedApiKey(ValidateHashedApiKeyRequest) returns (ValidateHashedApiKeyResponse);
+
 }
 
 message IssueApiKeyRequest {}
@@ -41,6 +43,19 @@ message GetHashedApiKeyResponse{
     string hashedApiKey = 2;
   }
   
+  oneof error_optional{
+    string error = 3;
+  }
+
+}
+
+message ValidateHashedApiKeyRequest{
+  string hashedApiKey = 1;
+}
+message ValidateHashedApiKeyResponse{
+  bool success =1;
+  bool validHash = 2;
+    
   oneof error_optional{
     string error = 3;
   }

--- a/packages/proto/auth-service/api_key.proto
+++ b/packages/proto/auth-service/api_key.proto
@@ -5,6 +5,7 @@ package authservice.api_key;
 service ApiKeyService {
   rpc issueApiKey(IssueApiKeyRequest) returns (IssueApiKeyResponse);
   rpc revokeApiKey(RevokeApiKeyRequest) returns (RevokeApiKeyResponse);
+  rpc isValidApiKey(IsValidApiKeyRequest) returns (IsValidApiKeyResponse);
 }
 
 message IssueApiKeyRequest {}
@@ -12,3 +13,6 @@ message IssueApiKeyResponse {}
 
 message RevokeApiKeyRequest {}
 message RevokeApiKeyResponse {}
+
+message IsValidApiKeyRequest{}
+message IsValidApiKeyResponse{}

--- a/packages/proto/auth-service/jwt.proto
+++ b/packages/proto/auth-service/jwt.proto
@@ -9,6 +9,15 @@ service JwtService {
 
 service InternalJwtService{
   rpc createJwtFromProjectInfo(CreateJwtProjectInfo) returns(CreateJwtInfo);
+  rpc verifyJwt(JwtForVerificationInfo) returns (VerificationInfo);
+}
+
+message JwtForVerificationInfo {
+  string jwt = 1;
+}
+
+message VerificationInfo{
+  bool verified = 1;
 }
 
 message CreateJwtProjectInfo{
@@ -37,5 +46,17 @@ message CreateJwtResponse {
   }
 }
 
-message ValidateJwtRequest {}
-message ValidateJwtResponse {}
+message ValidateJwtRequestHeader{
+  string authorization = 1 [json_name = "Authorization"];
+}
+message ValidateJwtRequest {
+  ValidateJwtRequestHeader header = 1;  
+}
+message ValidateJwtResponse {
+  bool success = 1;
+  bool verified = 2;
+  oneof error_optional{
+    string error = 3;
+  }
+
+}

--- a/packages/proto/auth-service/jwt.proto
+++ b/packages/proto/auth-service/jwt.proto
@@ -7,17 +7,30 @@ service JwtService {
   rpc validateJwt(ValidateJwtRequest) returns (ValidateJwtResponse);
 }
 
+service InternalJwtService{
+  rpc createJwtFromProjectInfo(CreateJwtProjectInfo) returns(CreateJwtInfo);
+}
+
+message CreateJwtProjectInfo{
+  string hashedApiKey = 1;
+  string projectId = 2;
+  repeated string scopes = 3;
+}
+
+message CreateJwtInfo{
+  string jwt = 1;
+}
+
 message CreateJwtRequestHeader{
   string X_Api_Key = 1 [json_name = "X-Api-Key"];
 }
-
 message CreateJwtRequest {
   CreateJwtRequestHeader header = 1;  
 }
 message CreateJwtResponse {
   bool success = 1;
   oneof error_optional{
-    string error = 3;
+    string error = 2;
   }
   oneof jwt_optional{
     string jwt = 3;

--- a/packages/proto/auth-service/jwt.proto
+++ b/packages/proto/auth-service/jwt.proto
@@ -18,6 +18,11 @@ message JwtForVerificationInfo {
 
 message VerificationInfo{
   bool verified = 1;
+
+
+  oneof hashed_api_key_optional{
+    string hashedApiKey = 2;
+  }
 }
 
 message CreateJwtProjectInfo{

--- a/packages/proto/auth-service/jwt.proto
+++ b/packages/proto/auth-service/jwt.proto
@@ -7,8 +7,22 @@ service JwtService {
   rpc validateJwt(ValidateJwtRequest) returns (ValidateJwtResponse);
 }
 
-message CreateJwtRequest {}
-message CreateJwtResponse {}
+message CreateJwtRequestHeader{
+  string X_Api_Key = 1 [json_name = "X-Api-Key"];
+}
+
+message CreateJwtRequest {
+  CreateJwtRequestHeader header = 1;  
+}
+message CreateJwtResponse {
+  bool success = 1;
+  oneof error_optional{
+    string error = 3;
+  }
+  oneof jwt_optional{
+    string jwt = 3;
+  }
+}
 
 message ValidateJwtRequest {}
 message ValidateJwtResponse {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1152,6 +1152,13 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.14.tgz#74a97a5573980802f32c8e47b663530ab3b6b7d1"
   integrity sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw==
 
+"@types/jsonwebtoken@^9.0.5":
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-9.0.5.tgz#0bd9b841c9e6c5a937c17656e2368f65da025588"
+  integrity sha512-VRLSGzik+Unrup6BsouBeHsf4d1hOEgYWTm/7Nmw1sXoN1+tRly/Gy/po3yeahnP4jfnQWWAhQAqcNfH7ngOkA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/mime@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.3.tgz#886674659ce55fe7c6c06ec5ca7c0eb276a08f91"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1817,6 +1817,11 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
+
 buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
@@ -2320,6 +2325,13 @@ duplexer@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
+
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -3762,6 +3774,39 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonwebtoken@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz#65ff91f4abef1784697d40952bb1998c504caaf3"
+  integrity sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^7.5.4"
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
+
 keyv@^4.5.3:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
@@ -3826,6 +3871,36 @@ lodash.camelcase@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==
+
 lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -3835,6 +3910,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
 lodash@4.17.21, lodash@^4.17.21:
   version "4.17.21"
@@ -4036,7 +4116,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3:
+ms@2.1.3, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -4713,7 +4793,7 @@ rxjs@7.8.1, rxjs@^7.5.5, rxjs@^7.8.1:
   dependencies:
     tslib "^2.1.0"
 
-safe-buffer@5.2.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==


### PR DESCRIPTION
## Issues

Fixes #3 and #5 

## Testing

- Yeah, idk how to test this, but my brain's compiler works when I walk through this, lol.

## Development Notes
- **Major Concern:** I have defined a lot of types in the proto folder - not sure if there is a better way to standardize this (both in terms of naming convention and when we should be defining new types) - but this is something we should definitely seek out to set.
- Right now, I have a couple of empty interfaces defined in the API key controller - i.e. `getProjectByApiKey`, `validateHashedApiKey`, and `getHashedApiKey` which need access to the database information - I'm not sure how this works but those will need to be filled in for the end to end flow to work -- EDIT: Need hayden to finish up his ticket to have a API key database service I can call
- I have a JWT secret coded in via environment variables but also have a back-up in case the person does not set this: `process.env.JWT_SECRET ?? 'secret'` --  we should find a way to define constants for testing environments (i.e. not hard code in `secret`)
- JWTs are set to expire in 60 mins 
- Only have minimal error handling and testing for now.
- Not sure if the structure of the code is correct