### PR TITLE
Write tests for Project API Endpoint #18

### DIFF
--- a/packages/api-gateway/test/app.e2e-spec.ts
+++ b/packages/api-gateway/test/app.e2e-spec.ts
@@ -57,46 +57,51 @@ describe('Project Creation Routes', () => {
         name: 'testProject',
       })
       .expect(201)
-      .expect("");
+      .expect('');
   });
 
-  it("Create a project with empty-string name", async () => {
+  it('Create a project with empty-string name', async () => {
     await request(app.getHttpServer())
       .post('/project')
       .send({
         name: '',
       })
       .expect(400)
-      .expect('{"message":["name should not be empty"],"error":"Bad Request","statusCode":400}');
+      .expect(
+        '{"message":["name should not be empty"],"error":"Bad Request","statusCode":400}',
+      );
   });
 
-  it("Create a project with no name field", async () => {
+  it('Create a project with no name field', async () => {
     await request(app.getHttpServer())
       .post('/project')
-      .send({
-      })
+      .send({})
       .expect(400)
-      .expect('{"message":["name should not be empty"],"error":"Bad Request","statusCode":400}');
+      .expect(
+        '{"message":["name should not be empty"],"error":"Bad Request","statusCode":400}',
+      );
   });
 
-  it("Create a project with null name", async () => {
+  it('Create a project with null name', async () => {
     await request(app.getHttpServer())
       .post('/project')
       .send({
         name: null,
       })
       .expect(400)
-      .expect('{"message":["name should not be empty"],"error":"Bad Request","statusCode":400}');
+      .expect(
+        '{"message":["name should not be empty"],"error":"Bad Request","statusCode":400}',
+      );
   });
 
-  it("Create a project with non-string name", async () => {
+  it('Create a project with non-string name', async () => {
     await request(app.getHttpServer())
       .post('/project')
       .send({
         name: 1,
       })
       .expect(201)
-      .expect("");
+      .expect('');
   });
 });
 
@@ -108,7 +113,7 @@ describe('Project Retrieval Routes', () => {
       .then((response) => {
         expect(response.body.name).toEqual('testProject');
         expect(response.body.id).toEqual(1);
-      })
+      });
   });
 
   it('Get project with valid name', async () => {
@@ -118,14 +123,14 @@ describe('Project Retrieval Routes', () => {
       .then((response) => {
         expect(response.body.name).toEqual('testProject');
         expect(response.body.id).toEqual(1);
-      })
+      });
   });
 
   it('Get project with non-number id', async () => {
     await request(app.getHttpServer())
       .get('/project/id/abc')
       .expect(400)
-      .expect('{"statusCode":400,"message":"id must be a number"}')
+      .expect('{"statusCode":400,"message":"id must be a number"}');
   });
 
   // it('Get project with non-existent id', async () => {
@@ -140,5 +145,102 @@ describe('Project Retrieval Routes', () => {
   //     .get('/project/name/abc')
   //     .expect(400)
   //     .expect('{"statusCode":400,"message":"name does not exist"}')
+  // });
+});
+
+describe('Project Update Routes', () => {
+  beforeAll(async () => {
+    await request(app.getHttpServer()).post('/user').send({
+      id: '1',
+      password: '1234',
+      name: 'Test User',
+      email: 'test@user.com',
+    });
+  });
+
+  it('Link user with project id using valid user id input', async () => {
+    await request(app.getHttpServer())
+      .put('/project/id/1/user')
+      .send({
+        id: '1',
+      })
+      .expect(200);
+  });
+
+  it('Link user with project id using valid user email input', async () => {
+    await request(app.getHttpServer())
+      .put('/project/id/1/user')
+      .send({
+        email: 'test@user.com',
+      })
+      .expect(200);
+  });
+
+  it('Link user with project id using non-number project id param', async () => {
+    await request(app.getHttpServer())
+      .put('/project/id/abc/user')
+      .send({
+        email: 'test@user.com',
+      })
+      .expect(400)
+      .expect('{"statusCode":400,"message":"id must be a number"}');
+  });
+
+  // it('Link user with project id using non-number user id input', async () => {
+  //   await request(app.getHttpServer())
+  //     .put('/project/id/1/user')
+  //     .send({
+  //       id: 'abc',
+  //     })
+  //     .expect(400)
+  //     .expect('{"statusCode":400,"message":"id must be a number"}');
+  // });
+
+  // it('Link user with project id using invalid user email input', async () => {
+  //   await request(app.getHttpServer())
+  //     .put('/project/id/1/user')
+  //     .send({
+  //       email: 'abc',
+  //     })
+  //     .expect(400)
+  //     .expect('');
+  // });
+
+  it('Link user with project name using valid user id input', async () => {
+    await request(app.getHttpServer())
+      .put('/project/name/testProject/user')
+      .send({
+        id: '1',
+      })
+      .expect(200);
+  });
+
+  it('Link user with project name using valid user email input', async () => {
+    await request(app.getHttpServer())
+      .put('/project/name/testProject/user')
+      .send({
+        email: 'test@user.com',
+      })
+      .expect(200);
+  });
+
+  // it('Link user with project name using non-number user id input', async () => {
+  //   await request(app.getHttpServer())
+  //     .put('/project/name/testProject/user')
+  //     .send({
+  //       id: 'abc',
+  //     })
+  //     .expect(400)
+  //     .expect('{"statusCode":400,"message":"id must be a number"}');
+  // });
+
+  // it('Link user with project name using invalid user email input', async () => {
+  //   await request(app.getHttpServer())
+  //     .put('/project/name/testProject/user')
+  //     .send({
+  //       email: 'abc',
+  //     })
+  //     .expect(400)
+  //     .expect('');
   // });
 });

--- a/packages/api-gateway/test/app.e2e-spec.ts
+++ b/packages/api-gateway/test/app.e2e-spec.ts
@@ -48,3 +48,54 @@ describe('Auth Routes', () => {
     request(app.getHttpServer()).get('/auth').expect(200).expect('');
   });
 });
+
+describe('Project Creation Routes', () => {
+  it('Create a project with valid inputs', async () => {
+    return await request(app.getHttpServer())
+      .post('/project')
+      .send({
+        name: 'testProject',
+      })
+      .expect(201)
+      .expect("");
+  });
+
+  it("Create a project with empty-string name", async () => {
+    return await request(app.getHttpServer())
+      .post('/project')
+      .send({
+        name: '',
+      })
+      .expect(400)
+      .expect('{"message":["name should not be empty"],"error":"Bad Request","statusCode":400}');
+  });
+
+  it("Create a project with no name field", async () => {
+    return await request(app.getHttpServer())
+      .post('/project')
+      .send({
+      })
+      .expect(400)
+      .expect('{"message":["name should not be empty"],"error":"Bad Request","statusCode":400}');
+  });
+
+  it("Create a project with null name", async () => {
+    return await request(app.getHttpServer())
+      .post('/project')
+      .send({
+        name: null,
+      })
+      .expect(400)
+      .expect('{"message":["name should not be empty"],"error":"Bad Request","statusCode":400}');
+  });
+
+  it("Create a project with non-string name", async () => {
+    return await request(app.getHttpServer())
+      .post('/project')
+      .send({
+        name: 1,
+      })
+      .expect(201)
+      .expect("");
+  });
+});

--- a/packages/api-gateway/test/app.e2e-spec.ts
+++ b/packages/api-gateway/test/app.e2e-spec.ts
@@ -45,13 +45,13 @@ beforeEach(async () => {
 // describe('Project Creation Routes', () => {});
 describe('Auth Routes', () => {
   it('Returns empty value', async () => {
-    request(app.getHttpServer()).get('/auth').expect(200).expect('');
+    await request(app.getHttpServer()).get('/auth').expect(200).expect('');
   });
 });
 
 describe('Project Creation Routes', () => {
   it('Create a project with valid inputs', async () => {
-    return await request(app.getHttpServer())
+    await request(app.getHttpServer())
       .post('/project')
       .send({
         name: 'testProject',
@@ -61,7 +61,7 @@ describe('Project Creation Routes', () => {
   });
 
   it("Create a project with empty-string name", async () => {
-    return await request(app.getHttpServer())
+    await request(app.getHttpServer())
       .post('/project')
       .send({
         name: '',
@@ -71,7 +71,7 @@ describe('Project Creation Routes', () => {
   });
 
   it("Create a project with no name field", async () => {
-    return await request(app.getHttpServer())
+    await request(app.getHttpServer())
       .post('/project')
       .send({
       })
@@ -80,7 +80,7 @@ describe('Project Creation Routes', () => {
   });
 
   it("Create a project with null name", async () => {
-    return await request(app.getHttpServer())
+    await request(app.getHttpServer())
       .post('/project')
       .send({
         name: null,
@@ -90,7 +90,7 @@ describe('Project Creation Routes', () => {
   });
 
   it("Create a project with non-string name", async () => {
-    return await request(app.getHttpServer())
+    await request(app.getHttpServer())
       .post('/project')
       .send({
         name: 1,
@@ -98,4 +98,47 @@ describe('Project Creation Routes', () => {
       .expect(201)
       .expect("");
   });
+});
+
+describe('Project Retrieval Routes', () => {
+  it('Get project with valid id', async () => {
+    await request(app.getHttpServer())
+      .get('/project/id/1')
+      .expect(200)
+      .then((response) => {
+        expect(response.body.name).toEqual('testProject');
+        expect(response.body.id).toEqual(1);
+      })
+  });
+
+  it('Get project with valid name', async () => {
+    await request(app.getHttpServer())
+      .get('/project/name/testProject')
+      .expect(200)
+      .then((response) => {
+        expect(response.body.name).toEqual('testProject');
+        expect(response.body.id).toEqual(1);
+      })
+  });
+
+  it('Get project with non-number id', async () => {
+    await request(app.getHttpServer())
+      .get('/project/id/abc')
+      .expect(400)
+      .expect('{"statusCode":400,"message":"id must be a number"}')
+  });
+
+  // it('Get project with non-existent id', async () => {
+  //   await request(app.getHttpServer())
+  //     .get('/project/id/0')
+  //     .expect(400)
+  //     .expect('{"statusCode":400,"message":"id does not exist"}')
+  // });
+
+  // it('Get project with non-existent name', async () => {
+  //   await request(app.getHttpServer())
+  //     .get('/project/name/abc')
+  //     .expect(400)
+  //     .expect('{"statusCode":400,"message":"name does not exist"}')
+  // });
 });


### PR DESCRIPTION
I added e2e tests for the Project API Endpoints. I commented out test cases where the project id/name does not exist in the database. As of now, I found that whenever I get a project that does not exist in the database, there will be internal errors. That might be due to a lack of error handling of these cases in the current server. Once this is resolved, I can uncomment the test cases to take care of the mentioned cases. Thanks