### PR TITLE
Add test watching & automatic test reset

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,7 +2,7 @@ FROM alpine as grpc-probe
 
 ARG TARGETARCH
 
-RUN apk add wget
+RUN --mount=type=cache,target=/var/cache/apk apk add wget
 
 COPY ./docker/get_grpc_probe.sh /get_grpc_probe.sh
 
@@ -14,7 +14,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN apk add --update python3 make g++ protoc bash && rm -rf /var/cache/apk/*
+RUN --mount=type=cache,target=/var/cache/apk apk add --update python3 make g++ protoc bash
 
 RUN yarn global add node-gyp 
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -50,6 +50,7 @@ services:
       AUTH_SERVICE_ADDR: auth-service:5000
       DB_SERVICE_ADDR: db-service:5000
       DATABASE_URL: postgresql://user:password@db
+      NODE_ENV: test
     networks:
       - bog-api-net
     depends_on:

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "gen-proto": "yarn workspace juno-proto install && yarn workspace juno-proto build",
     "preinstall": "yarn gen-proto",
     "test:e2e:api-gateway-live": "GATEWAY_COMMAND=test:e2e:watch RUN_MODE=test yarn start:dev:live-all --exit-code-from api-gateway",
-    "test:e2e:auth-service-live": "AUTH_COMMAND=test:e2e:watch RUN_MODE=test yarn start:dev:live-all --exit-code-from auth-service",
-    "test:e2e:db-service-live": "DB_COMMAND=test:e2e:watch RUN_MODE=test yarn start:dev:live-all --exit-code-from db-service",
+    "test:e2e:auth-service-live": "AUTH_COMMAND=test:e2e:watch RUN_MODE=test yarn start:dev:live-all --exit-code-from auth-service auth-service",
+    "test:e2e:db-service-live": "DB_COMMAND=test:e2e:watch RUN_MODE=test yarn start:dev:live-all --exit-code-from db-service db-service",
     "test:e2e:api-gateway": "GATEWAY_COMMAND=test:e2e RUN_MODE=test yarn start:dev --exit-code-from api-gateway",
     "test:e2e:auth-service": "AUTH_COMMAND=test:e2e RUN_MODE=test yarn start:dev --exit-code-from auth-service auth-service",
     "test:e2e:db-service": "DB_COMMAND=test:e2e RUN_MODE=test yarn start:dev --exit-code-from db-service db-service"

--- a/packages/api-gateway/src/modules/auth/auth.controller.ts
+++ b/packages/api-gateway/src/modules/auth/auth.controller.ts
@@ -16,8 +16,8 @@ export class AuthController implements OnModuleInit {
   ) {}
 
   onModuleInit() {
-    this.jwtService =
-      this.jwtClient.getService<JwtProto.JwtServiceClient>(JWT_SERVICE_NAME);
+    // this.jwtService =
+    //   this.jwtClient.getService<JwtProto.JwtServiceClient>(JWT_SERVICE_NAME);
     this.apiKeyService =
       this.apiClient.getService<ApiKeyProto.ApiKeyServiceClient>(
         ApiKeyProto.API_KEY_SERVICE_NAME,

--- a/packages/api-gateway/src/modules/project/project.controller.ts
+++ b/packages/api-gateway/src/modules/project/project.controller.ts
@@ -66,7 +66,7 @@ export class ProjectController implements OnModuleInit {
       name: params.name,
     });
 
-    await lastValueFrom(project);
+    return new ProjectResponse(await lastValueFrom(project));
   }
 
   @Put('id/:id/user')

--- a/packages/api-gateway/src/modules/user/user.controller.ts
+++ b/packages/api-gateway/src/modules/user/user.controller.ts
@@ -55,7 +55,7 @@ export class UserController implements OnModuleInit {
       type: UserProto.UserType.USER,
     });
 
-    await lastValueFrom(user);
+    return new UserResponse(await lastValueFrom(user));
   }
 
   @Post('type')

--- a/packages/auth-service/test/app.e2e-spec.ts
+++ b/packages/auth-service/test/app.e2e-spec.ts
@@ -9,6 +9,7 @@ import {
   ApiKeyProtoFile,
   JwtProto,
   JwtProtoFile,
+  ResetProtoFile,
 } from 'juno-proto';
 
 let app: INestMicroservice;
@@ -16,6 +17,22 @@ let app: INestMicroservice;
 
 const { AUTHSERVICE_API_KEY_PACKAGE_NAME } = ApiKeyProto;
 const { AUTHSERVICE_JWT_PACKAGE_NAME } = JwtProto;
+
+beforeAll(async () => {
+  const proto = ProtoLoader.loadSync([ResetProtoFile]) as any;
+
+  const protoGRPC = GRPC.loadPackageDefinition(proto) as any;
+  const resetClient = new protoGRPC.juno.reset_db.DatabaseReset(
+    process.env.DB_SERVICE_ADDR,
+    GRPC.credentials.createInsecure(),
+  );
+  await new Promise((resolve) => {
+    resetClient.resetDb({}, (err, resp) => {
+      console.log(resp);
+      resolve(0);
+    });
+  });
+});
 
 beforeEach(async () => {
   const moduleFixture: TestingModule = await Test.createTestingModule({

--- a/packages/db-service/package.json
+++ b/packages/db-service/package.json
@@ -33,6 +33,7 @@
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
+    "@grpc/proto-loader": "^0.7.10",
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",

--- a/packages/db-service/src/app.module.ts
+++ b/packages/db-service/src/app.module.ts
@@ -4,9 +4,10 @@ import { AppService } from './app.service';
 import { UserModule } from './modules/user/user.module';
 import { ProjectModule } from './modules/project/project.module';
 import { HealthModule } from './modules/health/health.module';
+import { ResetModule } from './modules/reset/reset.module';
 
 @Module({
-  imports: [UserModule, ProjectModule, HealthModule],
+  imports: [UserModule, ProjectModule, HealthModule, ResetModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/packages/db-service/src/main.ts
+++ b/packages/db-service/src/main.ts
@@ -11,6 +11,8 @@ import {
   ProjectProto,
   HealthProto,
   HealthProtoFile,
+  ResetProto,
+  ResetProtoFile,
 } from 'juno-proto';
 
 async function bootstrap() {
@@ -26,12 +28,14 @@ async function bootstrap() {
           UserProto.DBSERVICE_USER_PACKAGE_NAME,
           ProjectProto.DBSERVICE_PROJECT_PACKAGE_NAME,
           HealthProto.GRPC_HEALTH_V1_PACKAGE_NAME,
+          ResetProto.JUNO_RESET_DB_PACKAGE_NAME,
         ],
         protoPath: [
           UserProtoFile,
           ProjectProtoFile,
           IdentifiersProtoFile,
           HealthProtoFile,
+          ResetProtoFile,
         ],
         url: process.env.DB_SERVICE_ADDR,
       },

--- a/packages/db-service/src/modules/reset/reset.controller.ts
+++ b/packages/db-service/src/modules/reset/reset.controller.ts
@@ -1,0 +1,26 @@
+import { Controller } from '@nestjs/common';
+import { exec } from 'child_process';
+import { ResetProto } from 'juno-proto';
+
+@Controller()
+@ResetProto.DatabaseResetControllerMethods()
+export class ResetController implements ResetProto.DatabaseResetController {
+  async resetDb(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _request: ResetProto.ResetDbRequest,
+  ): Promise<ResetProto.ResetDbResponse> {
+    if (process.env['NODE_ENV'] == 'test') {
+      await new Promise((resolve) => {
+        exec(
+          'npx prisma migrate reset --force --skip-generate --skip-seed',
+          (_, stdout, stderr) => {
+            console.log(`reset out: ${stdout}`);
+            console.log(`reset err: ${stderr}`);
+            resolve(1);
+          },
+        );
+      });
+      return {};
+    }
+  }
+}

--- a/packages/db-service/src/modules/reset/reset.module.ts
+++ b/packages/db-service/src/modules/reset/reset.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { ResetController } from './reset.controller';
+
+@Module({
+  controllers: [ResetController],
+})
+export class ResetModule {}

--- a/packages/db-service/test/project.e2e-spec.ts
+++ b/packages/db-service/test/project.e2e-spec.ts
@@ -8,6 +8,8 @@ import {
   IdentifiersProtoFile,
   ProjectProto,
   ProjectProtoFile,
+  ResetProto,
+  ResetProtoFile,
   UserProto,
   UserProtoFile,
 } from 'juno-proto';
@@ -17,16 +19,25 @@ const { DBSERVICE_PROJECT_PACKAGE_NAME } = ProjectProto;
 
 let app: INestMicroservice;
 
-beforeEach(async () => {
+async function initApp() {
   const moduleFixture: TestingModule = await Test.createTestingModule({
     imports: [AppModule],
   }).compile();
 
-  app = moduleFixture.createNestMicroservice<MicroserviceOptions>({
+  const app = moduleFixture.createNestMicroservice<MicroserviceOptions>({
     transport: Transport.GRPC,
     options: {
-      package: [DBSERVICE_USER_PACKAGE_NAME, DBSERVICE_PROJECT_PACKAGE_NAME],
-      protoPath: [UserProtoFile, ProjectProtoFile, IdentifiersProtoFile],
+      package: [
+        DBSERVICE_USER_PACKAGE_NAME,
+        DBSERVICE_PROJECT_PACKAGE_NAME,
+        ResetProto.JUNO_RESET_DB_PACKAGE_NAME,
+      ],
+      protoPath: [
+        UserProtoFile,
+        ProjectProtoFile,
+        IdentifiersProtoFile,
+        ResetProtoFile,
+      ],
       url: process.env.DB_SERVICE_ADDR,
     },
   });
@@ -34,6 +45,30 @@ beforeEach(async () => {
   await app.init();
 
   await app.listen();
+  return app;
+}
+
+beforeAll(async () => {
+  const app = await initApp();
+
+  const proto = ProtoLoader.loadSync([ResetProtoFile]) as any;
+
+  const protoGRPC = GRPC.loadPackageDefinition(proto) as any;
+  const resetClient = new protoGRPC.juno.reset_db.DatabaseReset(
+    process.env.DB_SERVICE_ADDR,
+    GRPC.credentials.createInsecure(),
+  );
+  await new Promise((resolve) => {
+    resetClient.resetDb({}, () => {
+      resolve(0);
+    });
+  });
+
+  app.close();
+});
+
+beforeEach(async () => {
+  app = await initApp();
 });
 
 afterEach(async () => {

--- a/packages/proto/definitions/reset_db.proto
+++ b/packages/proto/definitions/reset_db.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package juno.reset_db;
+
+service DatabaseReset { rpc resetDb(ResetDbRequest) returns (ResetDbResponse); }
+
+message ResetDbRequest {}
+message ResetDbResponse {}

--- a/packages/proto/gen_protos.sh
+++ b/packages/proto/gen_protos.sh
@@ -12,3 +12,27 @@ protoc \
     --ts_proto_opt=lowerCaseServiceMethods=false \
     -I ${EXEC_PATH}/definitions/ \
     ${EXEC_PATH}/definitions/*.proto
+
+rm -rf ../${EXEC_PATH}/api-gateway/node_modules/juno-proto
+rm -rf ../${EXEC_PATH}/auth-service/node_modules/juno-proto
+rm -rf ../${EXEC_PATH}/db-service/node_modules/juno-proto
+
+mkdir -p ../${EXEC_PATH}/api-gateway/node_modules/juno-proto/dist
+mkdir -p ../${EXEC_PATH}/auth-service/node_modules/juno-proto/dist
+mkdir -p ../${EXEC_PATH}/db-service/node_modules/juno-proto/dist
+
+mkdir -p ../${EXEC_PATH}/api-gateway/node_modules/juno-proto/definitions
+mkdir -p ../${EXEC_PATH}/auth-service/node_modules/juno-proto/definitions
+mkdir -p ../${EXEC_PATH}/db-service/node_modules/juno-proto/definitions
+
+cp -r ${EXEC_PATH}/dist/* ../${EXEC_PATH}/api-gateway/node_modules/juno-proto/dist
+cp -r ${EXEC_PATH}/dist/* ../${EXEC_PATH}/auth-service/node_modules/juno-proto/dist
+cp -r ${EXEC_PATH}/dist/* ../${EXEC_PATH}/db-service/node_modules/juno-proto/dist
+
+cp -r ${EXEC_PATH}/definitions/* ../${EXEC_PATH}/api-gateway/node_modules/juno-proto/definitions
+cp -r ${EXEC_PATH}/definitions/* ../${EXEC_PATH}/auth-service/node_modules/juno-proto/definitions
+cp -r ${EXEC_PATH}/definitions/* ../${EXEC_PATH}/db-service/node_modules/juno-proto/definitions
+
+cp -r ${EXEC_PATH}/package.json ../${EXEC_PATH}/api-gateway/node_modules/juno-proto/
+cp -r ${EXEC_PATH}/package.json ../${EXEC_PATH}/auth-service/node_modules/juno-proto/
+cp -r ${EXEC_PATH}/package.json ../${EXEC_PATH}/db-service/node_modules/juno-proto/

--- a/packages/proto/src/gen/reset_db.ts
+++ b/packages/proto/src/gen/reset_db.ts
@@ -1,0 +1,52 @@
+/* eslint-disable */
+import { GrpcMethod, GrpcStreamMethod } from '@nestjs/microservices';
+import { Observable } from 'rxjs';
+
+export const protobufPackage = 'juno.reset_db';
+
+export interface ResetDbRequest {}
+
+export interface ResetDbResponse {}
+
+export const JUNO_RESET_DB_PACKAGE_NAME = 'juno.reset_db';
+
+export interface DatabaseResetClient {
+  resetDb(request: ResetDbRequest): Observable<ResetDbResponse>;
+}
+
+export interface DatabaseResetController {
+  resetDb(
+    request: ResetDbRequest,
+  ): Promise<ResetDbResponse> | Observable<ResetDbResponse> | ResetDbResponse;
+}
+
+export function DatabaseResetControllerMethods() {
+  return function (constructor: Function) {
+    const grpcMethods: string[] = ['resetDb'];
+    for (const method of grpcMethods) {
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(
+        constructor.prototype,
+        method,
+      );
+      GrpcMethod('DatabaseReset', method)(
+        constructor.prototype[method],
+        method,
+        descriptor,
+      );
+    }
+    const grpcStreamMethods: string[] = [];
+    for (const method of grpcStreamMethods) {
+      const descriptor: any = Reflect.getOwnPropertyDescriptor(
+        constructor.prototype,
+        method,
+      );
+      GrpcStreamMethod('DatabaseReset', method)(
+        constructor.prototype[method],
+        method,
+        descriptor,
+      );
+    }
+  };
+}
+
+export const DATABASE_RESET_SERVICE_NAME = 'DatabaseReset';

--- a/packages/proto/src/main.ts
+++ b/packages/proto/src/main.ts
@@ -4,11 +4,12 @@ export * as ProjectProto from './gen/project';
 export * as UserProto from './gen/user';
 export * as IdentifierProto from './gen/identifiers';
 export * as HealthProto from './gen/health';
+export * as ResetProto from './gen/reset_db';
 
 import { join } from 'path';
 
 function getProtoFilePath(name: string) {
-  return join(__dirname, '../../', 'juno-proto/definitions', name);
+  return join(__dirname, '../../', 'juno-proto/dist/definitions', name);
 }
 
 export const ApiKeyProtoFile = getProtoFilePath('api_key.proto');
@@ -17,3 +18,4 @@ export const ProjectProtoFile = getProtoFilePath('project.proto');
 export const UserProtoFile = getProtoFilePath('user.proto');
 export const IdentifiersProtoFile = getProtoFilePath('identifiers.proto');
 export const HealthProtoFile = getProtoFilePath('health.proto');
+export const ResetProtoFile = getProtoFilePath('reset_db.proto');


### PR DESCRIPTION
Adds the functionality to watch the live tests (e2e targets with `-live` at the end) and automatically resets the database before tests in a file start