### PR TITLE
Fix gen-proto not being automatically called

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "packageManager": "pnpm@9.11.0",
   "name": "bitsofgood-api",
   "scripts": {
-    "preinstall": "pnpm --filter juno-proto gen-proto",
+    "preinstall": "pnpm --filter . gen-proto",
     "start:dev": "docker compose -f docker-compose-dev.yml up",
     "start:dev:watch-packages": "docker compose -f docker-compose-dev.yml -f docker/docker-compose-live-packages.yml watch --no-up",
     "start:dev:watch-proto": "docker compose -f docker-compose-dev.yml -f docker/docker-compose-live-proto.yml watch --no-up",


### PR DESCRIPTION
With the PNPM migration there have been several hidden consequences of switching from yarn workspaces:
- The preinstall script for the parent package.json originally called gen-proto, a command present in both package.json files
- For yarn, it prioritizes and runs the script found within the same package.json (the parent gen-proto ) necessary for building juno proto.
-  For pnpm, it calls every script in any workspace folder named gen-proto, causing an infinite dependency loop
- The workaround was previously to filter to juno-proto, but this causes the root gen-proto to not be called. Switching to use the parent package.json solves this issue.