### PR TITLE
Add replyToList, optional recipients

### DIFF
--- a/packages/api-gateway/src/models/email.dto.ts
+++ b/packages/api-gateway/src/models/email.dto.ts
@@ -194,8 +194,8 @@ export class SendEmailModel {
     type: [EmailRecipient],
     description: 'List of recipients for the email',
   })
-  @ArrayNotEmpty()
   @ValidateNested({ each: true })
+  @IsOptional()
   @Type(() => EmailRecipient)
   recipients: EmailRecipient[];
 
@@ -216,6 +216,15 @@ export class SendEmailModel {
   @IsOptional()
   @Type(() => EmailRecipient)
   bcc: EmailRecipient[] = [];
+
+  @ApiProperty({
+    type: [EmailRecipient],
+    description: 'List of emails to add to the Reply To list of the email',
+  })
+  @ValidateNested({ each: true })
+  @IsOptional()
+  @Type(() => EmailRecipient)
+  replyToList: EmailRecipient[] = [];
 
   @ApiProperty({ type: EmailSender, description: 'The sender of the email' })
   @ValidateNested({ each: true })

--- a/packages/api-gateway/src/modules/email/email.controller.ts
+++ b/packages/api-gateway/src/modules/email/email.controller.ts
@@ -208,6 +208,7 @@ export class EmailController implements OnModuleInit {
             email: req.sender.email,
             name: req.sender.name,
           },
+          replyToList: req.replyToList,
           subject: req.subject,
           content: req.content,
           configId: apiKey.project.id,

--- a/packages/email-service/src/modules/email/email.service.ts
+++ b/packages/email-service/src/modules/email/email.service.ts
@@ -146,6 +146,7 @@ export class EmailService implements OnModuleInit {
           to: request.recipients,
           cc: request.cc,
           bcc: request.bcc,
+          replyToList: request.replyToList,
           from: {
             email: request.sender.email,
             name: request.sender.name,

--- a/packages/proto/definitions/email.proto
+++ b/packages/proto/definitions/email.proto
@@ -42,6 +42,7 @@ message SendEmailRequest {
   repeated EmailContent content = 6;
   int64 configId = 7;
   string configEnvironment = 8;
+  repeated EmailRecipient reply_to_list = 9;
 }
 
 message SenderInfo {

--- a/packages/proto/src/gen/email.ts
+++ b/packages/proto/src/gen/email.ts
@@ -27,6 +27,7 @@ export interface SendEmailRequest {
   content: EmailContent[];
   configId: number;
   configEnvironment: string;
+  replyToList: EmailRecipient[];
 }
 
 export interface SenderInfo {


### PR DESCRIPTION
- Fixed bug where although recipients was optional, the validation required a non-empty list
- Added replyToList functionality (see https://www.twilio.com/docs/sendgrid/api-reference/mail-send/mail-send)