### PR TITLE
Change subdomain to be optional

### DIFF
--- a/packages/api-gateway/src/models/email.dto.ts
+++ b/packages/api-gateway/src/models/email.dto.ts
@@ -187,8 +187,7 @@ export class RegisterDomainModel {
     example: 'subdomain',
     description: 'Subdomain to be registered',
   })
-  @IsNotEmpty()
-  subdomain: string;
+  subdomain?: string | undefined;
 }
 
 export class VerifyDomainModel {

--- a/packages/api-gateway/src/modules/email/email.controller.ts
+++ b/packages/api-gateway/src/modules/email/email.controller.ts
@@ -110,7 +110,7 @@ export class EmailController implements OnModuleInit {
   }
 
   @ApiOperation({
-    summary: 'Registers a sender domain.',
+    summary: 'Registers a sender domain with SendGrid.',
   })
   @ApiCreatedResponse({
     description: 'Domain registered successfully',

--- a/packages/db-service/prisma/migrations/20250221013556_set_email_subdomain_optional/migration.sql
+++ b/packages/db-service/prisma/migrations/20250221013556_set_email_subdomain_optional/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "EmailDomain" ALTER COLUMN "subdomain" DROP NOT NULL;

--- a/packages/db-service/prisma/schema.prisma
+++ b/packages/db-service/prisma/schema.prisma
@@ -93,7 +93,7 @@ model EmailSender {
 
 model EmailDomain {
   domain          String                        @id()
-  subdomain       String
+  subdomain       String?
   sendgridId      Int
   attachedConfigs EmailServiceConfigAndDomain[]
   EmailSender     EmailSender[]

--- a/packages/proto/definitions/email.proto
+++ b/packages/proto/definitions/email.proto
@@ -133,7 +133,7 @@ message SendGridRecord {
 
 message EmailDomain {
   string domain = 1;
-  string subdomain = 2;
+  optional string subdomain = 2;
   int64 sendgridId = 3;
   repeated identifiers.ProjectIdentifier projects = 4;
 }
@@ -142,7 +142,7 @@ message EmailDomainRequest { string domain = 1; }
 
 message CreateEmailDomainRequest {
   string domain = 1;
-  string subdomain = 2;
+  optional string subdomain = 2;
   int64 sendgridId = 3;
   int64 configId = 4;
   string configEnvironment = 5;

--- a/packages/proto/src/gen/email.ts
+++ b/packages/proto/src/gen/email.ts
@@ -124,7 +124,7 @@ export interface SendGridRecord {
 
 export interface EmailDomain {
   domain: string;
-  subdomain: string;
+  subdomain?: string | undefined;
   sendgridId: number;
   projects: ProjectIdentifier[];
 }
@@ -135,7 +135,7 @@ export interface EmailDomainRequest {
 
 export interface CreateEmailDomainRequest {
   domain: string;
-  subdomain: string;
+  subdomain?: string | undefined;
   sendgridId: number;
   configId: number;
   configEnvironment: string;


### PR DESCRIPTION
- Fixed a discrepancy where subdomain was a required field in API gateway requests despite being optional in [SendGrid's documentation](https://www.twilio.com/docs/sendgrid/api-reference/domain-authentication/authenticate-a-domain).