### PR TITLE
User and project deletion routes + email setup tweak

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "test:e2e:email-service": "EMAIL_COMMAND=test:e2e RUN_MODE=test pnpm start:dev --exit-code-from email-service email-service",
     "test:e2e:file-service": "FILE_COMMAND=test:e2e RUN_MODE=test pnpm start:dev --exit-code-from file-service file-service",
     "test:e2e:db-service": "DB_COMMAND=test:e2e RUN_MODE=test pnpm start:dev --exit-code-from db-service db-service",
-    "test:e2e:logging-service": "LOGGING_COMMAND=test:e2e RUN_MODE=test pnpm start:dev --exit-code-from logging-service logging-service"
+    "test:e2e:logging-service": "LOGGING_COMMAND=test:e2e RUN_MODE=test pnpm start:dev --exit-code-from logging-service logging-service",
+    "studio": "scripts/launch-prisma-studio.sh"
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.13.5",

--- a/packages/api-gateway/src/modules/project/project.module.ts
+++ b/packages/api-gateway/src/modules/project/project.module.ts
@@ -87,6 +87,7 @@ export class ProjectModule implements NestModule {
         { path: 'project', method: RequestMethod.POST },
         { path: 'project', method: RequestMethod.GET },
         { path: 'project/:id/users', method: RequestMethod.GET },
+        { path: 'project/id/:id', method: RequestMethod.DELETE },
       );
   }
 }

--- a/packages/api-gateway/src/modules/user/user.controller.ts
+++ b/packages/api-gateway/src/modules/user/user.controller.ts
@@ -307,6 +307,7 @@ export class UserController implements OnModuleInit {
   }
 
   @Delete('id/:id')
+  @ApiOperation({ summary: 'Delete an existing user.' })
   @ApiHeader({
     name: 'X-User-Email',
     description: 'Email of an admin or superadmin user',
@@ -326,7 +327,7 @@ export class UserController implements OnModuleInit {
   @ApiParam({
     name: 'id',
     required: true,
-    description: 'The unique identifier of the user',
+    description: 'ID of the user to be deleted',
     type: String,
   })
   @ApiResponse({
@@ -335,23 +336,17 @@ export class UserController implements OnModuleInit {
     type: UserResponse,
   })
   @ApiResponse({
-    status: HttpStatus.BAD_REQUEST,
-    description: 'Bad request',
-  })
-  @ApiResponse({
     status: HttpStatus.NOT_FOUND,
-    description: 'No user with id found',
+    description: 'No user with this ID was found',
   })
-  @ApiResponse({
-    status: HttpStatus.UNAUTHORIZED,
-    description: 'Unauthorized operation',
-  })
-  @ApiOperation({ summary: 'Delete an existing user.' })
-  async deleteUserById(@User() user: CommonProto.User, @Param('id') idStr: string): Promise<UserResponse> {
+  async deleteUserById(
+    @User() user: CommonProto.User,
+    @Param('id') idStr: string,
+  ): Promise<UserResponse> {
     if (user.type == CommonProto.UserType.USER) {
       throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
     }
-    
+
     const id = parseInt(idStr);
     if (Number.isNaN(id)) {
       throw new HttpException('ID must be a number', HttpStatus.BAD_REQUEST);

--- a/packages/api-gateway/src/modules/user/user.module.ts
+++ b/packages/api-gateway/src/modules/user/user.module.ts
@@ -79,6 +79,7 @@ export class UserModule implements NestModule {
         { path: 'user', method: RequestMethod.GET },
         { path: 'user/type', method: RequestMethod.POST },
         { path: 'user/id/:id/project', method: RequestMethod.PUT },
+        { path: 'user/id/:id', method: RequestMethod.DELETE },
       );
   }
 }

--- a/packages/api-gateway/test/email.e2e-spec.ts
+++ b/packages/api-gateway/test/email.e2e-spec.ts
@@ -126,6 +126,31 @@ describe('Email Service Setup Routes', () => {
       .expect(201);
   });
 
+  it('Replaces original sendgrid key when attempting to set up a service that already exists', async () => {
+    const apiKey = await createApiKey('test-seed-project', 'dev');
+    await request(app.getHttpServer())
+      .post('/email/setup')
+      .set('Authorization', 'Bearer ' + apiKey)
+      .send({
+        sendgridKey: 'test-key1',
+      });
+
+    await request(app.getHttpServer())
+      .post('/email/setup')
+      .set('Authorization', 'Bearer ' + apiKey)
+      .send({
+        sendgridKey: 'test-key2',
+      })
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .get('email/config/0')
+      .set('Authorization', 'Bearer ' + apiKey)
+      .then((response) => {
+        expect(response.body.sendgridKey).toEqual('test-key2');
+      });
+  });
+
   it('Fails without a sendgridKey', async () => {
     const apiKey = await createApiKey('test-seed-project', 'dev2');
     return request(app.getHttpServer())

--- a/packages/api-gateway/test/email.e2e-spec.ts
+++ b/packages/api-gateway/test/email.e2e-spec.ts
@@ -144,7 +144,7 @@ describe('Email Service Setup Routes', () => {
       .expect(201);
 
     await request(app.getHttpServer())
-      .get('email/config/0')
+      .get('/email/config/0')
       .set('Authorization', 'Bearer ' + apiKey)
       .then((response) => {
         expect(response.body.sendgridKey).toEqual('test-key2');

--- a/packages/api-gateway/test/project.e2e-spec.ts
+++ b/packages/api-gateway/test/project.e2e-spec.ts
@@ -437,7 +437,7 @@ describe('Project Deletion Routes', () => {
       .send({
         name: 'testproject2',
       });
-    
+
     // delete project
     await request(app.getHttpServer())
       .delete(`/project/id/${projId}`)

--- a/packages/api-gateway/test/project.e2e-spec.ts
+++ b/packages/api-gateway/test/project.e2e-spec.ts
@@ -438,6 +438,13 @@ describe('Project Deletion Routes', () => {
         name: 'testproject2',
       });
 
+    // check that user has one linked project
+    await request(app.getHttpServer())
+      .get(`/user/id/${userId}`)
+      .then((response) => {
+        expect(response.body.projectIds.length).toEqual(1);
+      });
+
     // delete project
     await request(app.getHttpServer())
       .delete(`/project/id/${projId}`)
@@ -448,7 +455,7 @@ describe('Project Deletion Routes', () => {
     await request(app.getHttpServer())
       .get(`/user/id/${userId}`)
       .then((response) => {
-        expect(response.body.projectIds.length).toEqual(0);
+        expect(response.body.projectIds).toBe(undefined);
       });
   });
 });

--- a/packages/api-gateway/test/user.e2e-spec.ts
+++ b/packages/api-gateway/test/user.e2e-spec.ts
@@ -253,7 +253,7 @@ describe('User Deletion Routes', () => {
       .set('X-User-Email', ADMIN_EMAIL)
       .set('X-User-Password', ADMIN_PASSWORD)
       .expect(404);
-  });  
+  });
 });
 
 describe('Credentials Middleware Tests (jwt authentication)', () => {

--- a/packages/api-gateway/test/user.e2e-spec.ts
+++ b/packages/api-gateway/test/user.e2e-spec.ts
@@ -227,6 +227,39 @@ describe('User Creation Routes', () => {
   });
 });
 
+describe('User Deletion Routes', () => {
+  it('deletes an existing user', async () => {
+    await request(app.getHttpServer())
+      .post('/user')
+      .set('X-User-Email', ADMIN_EMAIL)
+      .set('X-User-Password', ADMIN_PASSWORD)
+      .send({
+        id: '1',
+        password: 'pwd123',
+        name: 'John Doe',
+        email: 'john@example.com',
+      });
+
+    return request(app.getHttpServer())
+      .delete('/user/id/1')
+      .set('X-User-Email', ADMIN_EMAIL)
+      .set('X-User-Password', ADMIN_PASSWORD)
+      .send({
+      })
+      .expect(200);
+  });
+
+  it('fails to delete a nonexistent user', () => {
+    return request(app.getHttpServer())
+      .delete('/user/id/-1')
+      .set('X-User-Email', ADMIN_EMAIL)
+      .set('X-User-Password', ADMIN_PASSWORD)
+      .send({
+      })
+      .expect(404);
+  });  
+});
+
 describe('Credentials Middleware Tests (jwt authentication)', () => {
   it('gets users with authorized jwt', async () => {
     await request(app.getHttpServer())

--- a/packages/api-gateway/test/user.e2e-spec.ts
+++ b/packages/api-gateway/test/user.e2e-spec.ts
@@ -240,22 +240,18 @@ describe('User Deletion Routes', () => {
         email: 'john@example.com',
       });
 
-    return request(app.getHttpServer())
+    await request(app.getHttpServer())
       .delete('/user/id/1')
       .set('X-User-Email', ADMIN_EMAIL)
       .set('X-User-Password', ADMIN_PASSWORD)
-      .send({
-      })
       .expect(200);
   });
 
-  it('fails to delete a nonexistent user', () => {
-    return request(app.getHttpServer())
-      .delete('/user/id/-1')
+  it('fails to delete a nonexistent user', async () => {
+    await request(app.getHttpServer())
+      .delete('/user/id/100')
       .set('X-User-Email', ADMIN_EMAIL)
       .set('X-User-Password', ADMIN_PASSWORD)
-      .send({
-      })
       .expect(404);
   });  
 });

--- a/packages/db-service/src/modules/email/email.service.ts
+++ b/packages/db-service/src/modules/email/email.service.ts
@@ -142,8 +142,17 @@ export class EmailService {
   async createEmailServiceConfig(
     input: Prisma.EmailServiceConfigCreateInput,
   ): Promise<EmailServiceConfig> {
-    return this.prisma.emailServiceConfig.create({
-      data: input,
+    return this.prisma.emailServiceConfig.upsert({
+      where: {
+        id_environment: {
+          id: input.Project.connect.id,
+          environment: input.environment,
+        },
+      },
+      create: input,
+      update: {
+        sendgridApiKey: input.sendgridApiKey,
+      },
     });
   }
 

--- a/scripts/launch-prisma-studio.sh
+++ b/scripts/launch-prisma-studio.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Launches prisma studio given the current db-service port. 
+
+# extract db information from running juno instance
+db_container_id=$(docker ps -q --filter "ancestor=postgres")
+db_container_port=$(docker port $db_container_id)
+
+db_public_port=$(echo "$db_container_port" | grep -oP "0.0.0.0:\K\d+")
+
+# run prisma studio 
+cd packages/db-service
+
+DATABASE_URL="postgresql://user:password@localhost:$db_public_port/postgres" pnpm prisma studio 


### PR DESCRIPTION
Closes #182 

- new DELETE user/id/:id route
- new DELETE project/id/:id route, users automatically unlink from deleted project (side note: I think if there's an ApiKey, EmailServiceConfig, or FileServiceConfig that uses the project as a foreign key, you'll have to delete these first to avoid an error)
- only admin and superadmin users can delete users or projects
- changed createEmailServiceConfig so the existing Sendgrid key is updated if you try to setup an email service that already exists