### PR TITLE
Update error message when sendEmail does not find the email config

### DIFF
--- a/packages/db-service/src/modules/email/email.controller.ts
+++ b/packages/db-service/src/modules/email/email.controller.ts
@@ -47,7 +47,7 @@ export class EmailController implements EmailDbServiceController {
     if (!config) {
       throw new RpcException({
         code: status.NOT_FOUND,
-        message: 'Email config not found',
+        message: `Email config for environment "${request.environment}" not found`,
       });
     }
 

--- a/packages/db-service/src/modules/email/email.controller.ts
+++ b/packages/db-service/src/modules/email/email.controller.ts
@@ -47,7 +47,7 @@ export class EmailController implements EmailDbServiceController {
     if (!config) {
       throw new RpcException({
         code: status.NOT_FOUND,
-        message: `Email config for environment "${request.environment}" not found`,
+        message: `Email config not found for environment "${request.environment}." Are your config matches this environment?`,
       });
     }
 


### PR DESCRIPTION
Closes #186 

- Updates error message from "Email config not found" to "Email config for environment "[environment]" not found"