### PR TITLE
Davidgu/safeguard for email/password jwt generation route

### DIFF
--- a/packages/auth-service/src/modules/user/user.controller.ts
+++ b/packages/auth-service/src/modules/user/user.controller.ts
@@ -30,7 +30,12 @@ export class UserController implements UserProto.UserAuthServiceController {
         }),
       );
     } catch (e) {
-      console.log(`${JSON.stringify(e)}`);
+      // Only log unexpected errors to Sentry (NOT_FOUND is expected for invalid/deleted users)
+      if (e.code !== status.NOT_FOUND) {
+        console.log(
+          `Unexpected error in getUserPasswordHash: ${JSON.stringify(e)}`,
+        );
+      }
       throw new RpcException({
         code: status.NOT_FOUND,
         message: 'No user found for email',

--- a/packages/auth-service/src/modules/user/user.controller.ts
+++ b/packages/auth-service/src/modules/user/user.controller.ts
@@ -30,16 +30,23 @@ export class UserController implements UserProto.UserAuthServiceController {
         }),
       );
     } catch (e) {
-      // Only log unexpected errors to Sentry (NOT_FOUND is expected for invalid/deleted users)
-      if (e.code !== status.NOT_FOUND) {
+      // Handle expected NOT_FOUND errors (invalid/deleted users) vs unexpected errors
+      if (e.code === status.NOT_FOUND) {
+        // Expected case - user doesn't exist, don't log to Sentry
+        throw new RpcException({
+          code: status.NOT_FOUND,
+          message: 'No user found for email',
+        });
+      } else {
+        // Unexpected error (database failure, network issue, etc.) - log to Sentry
         console.log(
           `Unexpected error in getUserPasswordHash: ${JSON.stringify(e)}`,
         );
+        throw new RpcException({
+          code: status.UNKNOWN,
+          message: 'An unexpected error occurred during authentication',
+        });
       }
-      throw new RpcException({
-        code: status.NOT_FOUND,
-        message: 'No user found for email',
-      });
     }
 
     const passwordEquals = await bcrypt.compare(


### PR DESCRIPTION
Not a huge concern, but there currently isn't a guardrail for valid email/password but deleted user entry. The exception is still caught before returning to the user, but not before emitting an error metric in Sentry. 

# Fix

- [x] Add safeguard for invalid user when performing lookup via prisma in `authenticate` 

# Testing 

- [x] Additional test in DB Service validating `authenticate` correctly catches invalid prisma return
         Created the test in Auth-service.

authenticate now no longer logs a not found error and logs any other error from db service and throws an unknown error when that happens.